### PR TITLE
IPv6 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,6 @@
 # widelands_metaserver
 The game server that provides chat and hosting of games for Widelands.
+
+For information about the used network protocol, see the file
+> src/network/internet_gaming_protocol.h
+in the Widelands sources at https://launchpad.net/widelands

--- a/wlms/client.go
+++ b/wlms/client.go
@@ -67,7 +67,13 @@ type Client struct {
 	// the buildId of Widelands executable that this client is using.
 	buildId string
 
-	// the nonce to link multiple connections by the same client.
+	// The nonce to link multiple connections by the same client.
+	// When a network client connects with (RE)LOGIN he also sends a nonce
+	// which is stored in this field. When "another" netclient connects and
+	// sends TELL_IP containing the same nonce, it is considered the
+	// same game client connecting with another IP.
+	// This way, two connections by IPv4 and IPv6 can be matched so
+	// the server learns both addresses of the client.
 	nonce string
 
 	// the IP of the secondary connection.
@@ -271,7 +277,7 @@ func (client *Client) restartPingLoop(pingCycleTime time.Duration) {
 func (client Client) remoteIp() string {
 	host, _, err := net.SplitHostPort(client.conn.RemoteAddr().String())
 	if err != nil {
-		log.Fatalf("%s is not valid.", client.remoteIp())
+		log.Fatalf("%s has no valid ip address.", client.userName)
 	}
 	return host
 }

--- a/wlms/client.go
+++ b/wlms/client.go
@@ -67,6 +67,17 @@ type Client struct {
 	// the buildId of Widelands executable that this client is using.
 	buildId string
 
+	// the nonce to link multiple connections by the same client.
+	nonce string
+
+	// the IP of the secondary connection.
+	// usually this is an IPv4 address.
+	secondaryIp string
+
+	// Whether this client has a known IPv4/6 address.
+	hasV4 bool
+	hasV6 bool
+
 	// The game we are currently in. nil if not in game.
 	game *Game
 
@@ -154,6 +165,13 @@ func DealWithNewConnection(conn ReadWriteCloserWithIp, server *Server) {
 	client.startToPingTimer.Reset(server.PingCycleTime())
 	client.timeoutTimer.Reset(server.ClientSendingTimeout())
 	client.waitingForPong = false
+
+	ip := net.ParseIP(client.remoteIp())
+	if ip.To4() != nil {
+		client.hasV4 = true
+	} else {
+		client.hasV6 = true
+	}
 
 	for {
 		select {
@@ -258,6 +276,10 @@ func (client Client) remoteIp() string {
 	return host
 }
 
+func (client Client) otherIp() string {
+	return client.secondaryIp
+}
+
 func (newClient *Client) successfulRelogin(server *Server, oldClient *Client) {
 	server.RemoveClient(oldClient)
 
@@ -338,8 +360,16 @@ func (c *Client) Handle_LOGIN(server *Server, pkg *packet.Packet) CmdError {
 		return CriticalCmdPacketError{err.Error()}
 	}
 
-	if c.protocolVersion != 0 {
+	if c.protocolVersion != 0 && c.protocolVersion != 1 {
 		return CriticalCmdPacketError{"UNSUPPORTED_PROTOCOL"}
+	}
+
+	if isRegisteredOnServer || c.protocolVersion == 1 {
+		nonce, err := pkg.ReadString()
+		if err != nil {
+			return CriticalCmdPacketError{err.Error()}
+		}
+		c.nonce = nonce
 	}
 
 	if isRegisteredOnServer {
@@ -349,11 +379,7 @@ func (c *Client) Handle_LOGIN(server *Server, pkg *packet.Packet) CmdError {
 		if !server.UserDb().ContainsName(c.userName) {
 			return CriticalCmdPacketError{"WRONG_PASSWORD"}
 		}
-		password, err := pkg.ReadString()
-		if err != nil {
-			return CriticalCmdPacketError{err.Error()}
-		}
-		if !server.UserDb().PasswordCorrect(c.userName, password) {
+		if !server.UserDb().PasswordCorrect(c.userName, c.nonce) {
 			return CriticalCmdPacketError{"WRONG_PASSWORD"}
 		}
 		c.permissions = server.UserDb().Permissions(c.userName)
@@ -381,9 +407,17 @@ func (c *Client) Handle_LOGIN(server *Server, pkg *packet.Packet) CmdError {
 func (client *Client) Handle_RELOGIN(server *Server, pkg *packet.Packet) CmdError {
 	var isRegisteredOnServer bool
 	var protocolVersion int
-	var userName, buildId string
+	var userName, buildId, nonce string
 	if err := pkg.Unpack(&protocolVersion, &userName, &buildId, &isRegisteredOnServer); err != nil {
 		return CriticalCmdPacketError{err.Error()}
+	}
+
+	if isRegisteredOnServer || protocolVersion == 1 {
+		n, err := pkg.ReadString()
+		if err != nil {
+			return CriticalCmdPacketError{err.Error()}
+		}
+		nonce = n
 	}
 
 	oldClient := server.HasClient(userName)
@@ -396,11 +430,7 @@ func (client *Client) Handle_RELOGIN(server *Server, pkg *packet.Packet) CmdErro
 			buildId == oldClient.buildId
 
 	if isRegisteredOnServer {
-		password, err := pkg.ReadString()
-		if err != nil {
-			return CriticalCmdPacketError{err.Error()}
-		}
-		if oldClient.permissions == UNREGISTERED || !server.UserDb().PasswordCorrect(userName, password) {
+		if oldClient.permissions == UNREGISTERED || !server.UserDb().PasswordCorrect(userName, nonce) {
 			informationMatches = false
 		}
 	} else if oldClient.permissions != UNREGISTERED {
@@ -417,6 +447,7 @@ func (client *Client) Handle_RELOGIN(server *Server, pkg *packet.Packet) CmdErro
 	client.userName = oldClient.userName
 	client.buildId = oldClient.buildId
 	client.game = oldClient.game
+	client.nonce = nonce
 
 	log.Printf("%s wants to reconnect.\n", client.Name())
 	if oldClient.state == RECENTLY_DISCONNECTED {
@@ -431,6 +462,42 @@ func (client *Client) Handle_RELOGIN(server *Server, pkg *packet.Packet) CmdErro
 	}
 	return nil
 }
+
+func (client *Client) Handle_TELL_IP(server *Server, pkg *packet.Packet) CmdError {
+	var protocolVersion int
+	var name, nonce string
+	if err := pkg.Unpack(&protocolVersion, &name, &nonce); err != nil {
+		return CmdPacketError{err.Error()}
+	}
+
+	if protocolVersion != 1 {
+		return CriticalCmdPacketError{"UNSUPPORTED_PROTOCOL"}
+	}
+
+	old_client := server.HasClient(name)
+	if old_client == nil || old_client.userName != name || old_client.nonce != nonce {
+		log.Printf("Someone failed to register an IP for %s.", old_client.Name())
+		return CriticalCmdPacketError{"NOT_LOGGED_IN"}
+	}
+
+	// We found the existing connection of this client.
+	// Update his IP and close this connection.
+	old_client.secondaryIp = client.remoteIp()
+	ip := net.ParseIP(old_client.otherIp())
+	if ip.To4() != nil {
+		old_client.hasV4 = true
+	} else {
+		old_client.hasV6 = true
+	}
+	log.Printf("%s is now known to use %s and %s.", old_client.Name(), old_client.remoteIp(), old_client.otherIp())
+	client.Disconnect(*server)
+	// Tell the client to get a new list of games. The availability of games might have changed now that
+	// he supports more IP versions
+	old_client.SendPacket("GAMES_UPDATE")
+
+	return nil
+}
+
 
 func (client *Client) Handle_GAME_OPEN(server *Server, pkg *packet.Packet) CmdError {
 	var gameName string
@@ -463,9 +530,36 @@ func (client *Client) Handle_GAME_CONNECT(server *Server, pkg *packet.Packet) Cm
 	}
 
 	host := server.HasClient(game.Host())
-	log.Printf("%s joined %s at IP %s.", client.userName, game.Name(), host.remoteIp())
+	log.Printf("%s joined %s.", client.userName, game.Name())
 
-	client.SendPacket("GAME_CONNECT", host.remoteIp())
+	var ipv4, ipv6 string
+	ip := net.ParseIP(host.remoteIp())
+	if ip.To4() != nil {
+		ipv4 = host.remoteIp()
+		ipv6 = host.otherIp()
+	} else {
+		ipv4 = host.otherIp()
+		ipv6 = host.remoteIp()
+	}
+	if client.protocolVersion == 0 {
+		// Legacy client: Send the IPv4 address
+		client.SendPacket("GAME_CONNECT", ipv4)
+		// One of the two has to be IPv4, otherwise the client wouldn't come this
+		// far anyway (game would appear closed)
+	} else {
+		// Newer client which supports two IPs
+		// Only send him the IPs he can deal with
+		if client.hasV4 && client.hasV6 && host.otherIp() != "" {
+			// Both client and server have both IPs
+			client.SendPacket("GAME_CONNECT", ipv6, true, ipv4)
+		} else if client.hasV4 && len(ipv4) != 0 {
+			// Client and server have an IPv4 address
+			client.SendPacket("GAME_CONNECT", ipv4, false)
+		} else if client.hasV6 && len(ipv6) != 0 {
+			// Client and server have an IPv6 address
+			client.SendPacket("GAME_CONNECT", ipv6, false)
+		}
+	}
 	client.setGame(game, server)
 
 	return nil
@@ -526,7 +620,15 @@ func (client *Client) Handle_GAMES(server *Server, pkg *packet.Packet) CmdError 
 		host := server.HasClient(game.Host())
 		data[n+0] = game.Name()
 		data[n+1] = host.buildId
-		data[n+2] = game.State() == CONNECTABLE
+		// A game is connectable when the client supports the IP version of the game
+		// (and the game is connectable itself, of course)
+		connectable := game.State() == CONNECTABLE_BOTH
+		if client.hasV4 && game.State() == CONNECTABLE_V4 {
+			connectable = true
+		} else if client.hasV6 && game.State() == CONNECTABLE_V6 {
+			connectable = true
+		}
+		data[n+2] = connectable
 		n += 3
 	})
 	client.SendPacket(data...)

--- a/wlms/game.go
+++ b/wlms/game.go
@@ -3,6 +3,7 @@ package main
 import (
 	"log"
 	"time"
+	"net"
 )
 
 type GameState int
@@ -10,7 +11,9 @@ type GameState int
 const (
 	INITIAL_SETUP GameState = iota
 	NOT_CONNECTABLE
-	CONNECTABLE
+	CONNECTABLE_V4
+	CONNECTABLE_V6
+	CONNECTABLE_BOTH
 	RUNNING
 )
 
@@ -27,11 +30,70 @@ type GamePinger struct {
 	C chan bool
 }
 
+func (game *Game) handlePingResult(server *Server, result bool, is_v4 bool) {
+	if result {
+		log.Printf("Successfull ping reply from game %s.", game.Name())
+		switch game.state {
+		case INITIAL_SETUP:
+			if is_v4 {
+				game.SetState(*server, CONNECTABLE_V4)
+			} else {
+				game.SetState(*server, CONNECTABLE_V6)
+			}
+		case NOT_CONNECTABLE:
+			if is_v4 {
+				game.SetState(*server, CONNECTABLE_V4)
+			} else {
+				game.SetState(*server, CONNECTABLE_V6)
+			}
+		case CONNECTABLE_V4:
+			if !is_v4 {
+				game.SetState(*server, CONNECTABLE_BOTH)
+			}
+		case CONNECTABLE_V6:
+			if is_v4 {
+				game.SetState(*server, CONNECTABLE_BOTH)
+			}
+		case CONNECTABLE_BOTH, RUNNING:
+			// Do nothing
+		default:
+			log.Fatalf("Unhandled game.state: %v", game.state)
+		}
+	} else {
+		log.Printf("Failed ping reply from game %s.", game.Name())
+		switch game.state {
+		case INITIAL_SETUP:
+			game.SetState(*server, NOT_CONNECTABLE)
+		case NOT_CONNECTABLE:
+			// Do nothing.
+		case CONNECTABLE_V4:
+			if is_v4 {
+				game.SetState(*server, NOT_CONNECTABLE)
+			}
+		case CONNECTABLE_V6:
+			if !is_v4 {
+				game.SetState(*server, NOT_CONNECTABLE)
+			}
+		case CONNECTABLE_BOTH:
+			if is_v4 {
+				game.SetState(*server, CONNECTABLE_V6)
+			} else {
+				game.SetState(*server, CONNECTABLE_V4)
+			}
+		case RUNNING:
+			// Do nothing
+		default:
+			log.Fatalf("Unhandled game.state: %v", game.state)
+		}
+	}
+}
+
 func (game *Game) pingCycle(server *Server) {
 	// Remember to remove the game when we no longer receive pings.
 	defer server.RemoveGame(game)
 
 	first_ping := true
+	ping_primary_ip := true
 	for {
 		// This game is not even in our list anymore. Give up. If the game has no
 		// host anymore or it has disconnected, remove the game.
@@ -46,37 +108,37 @@ func (game *Game) pingCycle(server *Server) {
 		if first_ping {
 			pingTimeout = server.GameInitialPingTimeout()
 		}
-		first_ping = false
 
-		pinger := server.NewGamePinger(host, pingTimeout)
-		success, ok := <-pinger.C
-		if success && ok {
-			log.Printf("Successfull ping reply from game %s.", game.Name())
-			switch game.state {
-			case INITIAL_SETUP:
-				host.SendPacket("GAME_OPEN")
-				game.SetState(*server, CONNECTABLE)
-			case NOT_CONNECTABLE:
-				game.SetState(*server, CONNECTABLE)
-			case CONNECTABLE, RUNNING:
-				// Do nothing
-			default:
-				log.Fatalf("Unhandled game.state: %v", game.state)
-			}
-		} else {
-			log.Printf("Failed ping reply from game %s.", game.Name())
-			switch game.state {
-			case INITIAL_SETUP:
-				host.SendPacket("ERROR", "GAME_OPEN", "GAME_TIMEOUT")
-				game.SetState(*server, NOT_CONNECTABLE)
-			case NOT_CONNECTABLE:
-				// Do nothing.
-			case CONNECTABLE, RUNNING:
-				return
-			default:
-				log.Fatalf("Unhandled game.state: %v", game.state)
-			}
+		connected := false
+
+		// The idea is to alternate between pinging the two IP addresses of the client, except for the
+		// first round or if there is only one IP address
+		if ping_primary_ip || host.otherIp() == "" {
+			// Primary IP
+			pinger := server.NewGamePinger(host.remoteIp(), pingTimeout)
+			success, ok := <-pinger.C
+			connected = success && ok
+			game.handlePingResult(server, connected, net.ParseIP(host.remoteIp()).To4() != nil)
 		}
+		if (!ping_primary_ip || first_ping) && host.otherIp() != "" {
+			// Secondary IP
+			pinger := server.NewGamePinger(host.otherIp(), pingTimeout)
+			success, ok := <-pinger.C
+			connected = success && ok
+			game.handlePingResult(server, connected, net.ParseIP(host.otherIp()).To4() != nil)
+
+		}
+		if first_ping {
+			// On first ping, inform the client about the result
+			if connected {
+				host.SendPacket("GAME_OPEN")
+			} else {
+				host.SendPacket("ERROR", "GAME_OPEN", "GAME_TIMEOUT")
+			}
+			first_ping = false
+		}
+
+		ping_primary_ip = !ping_primary_ip
 		time.Sleep(server.GamePingTimeout())
 	}
 }

--- a/wlms/main.go
+++ b/wlms/main.go
@@ -28,6 +28,7 @@ func main() {
 	var db UserDb
 	var ircbridge IRCBridger
 	if config != "" {
+		log.Println("Loading configuration")
 		var cfg Config
 		if err := cfg.ConfigFrom(config); err != nil {
 			log.Fatalf("Could not parse config file: %v", err)
@@ -39,13 +40,16 @@ func main() {
 		}
 		ircbridge = NewIRCBridge(cfg.IRCServer, cfg.Realname, cfg.Nickname, cfg.Channel, cfg.UseTLS)
 	} else {
+		log.Println("No configuration found, using in-memory database")
 		db = NewInMemoryDb()
 	}
 	defer db.Close()
 
 	messagesToIrc := make(chan Message, 50)
 	messagesToLobby := make(chan Message, 50)
-	ircbridge.Connect(messagesToIrc, messagesToLobby)
+	if ircbridge != nil {
+		ircbridge.Connect(messagesToIrc, messagesToLobby)
+	}
 	RunServer(db, messagesToLobby, messagesToIrc)
 
 }

--- a/wlms/server.go
+++ b/wlms/server.go
@@ -38,7 +38,7 @@ type Server struct {
 }
 
 type GamePingerFactory interface {
-	New(client *Client, timeout time.Duration) *GamePinger
+	New(ip string, timeout time.Duration) *GamePinger
 }
 
 func (s Server) ClientSendingTimeout() time.Duration {
@@ -96,8 +96,8 @@ func (s *Server) WaitTillShutdown() {
 	<-s.serverHasShutdown
 }
 
-func (s *Server) NewGamePinger(client *Client, ping_timeout time.Duration) *GamePinger {
-	return s.gamePingerFactory.New(client, ping_timeout)
+func (s *Server) NewGamePinger(ip string, ping_timeout time.Duration) *GamePinger {
+	return s.gamePingerFactory.New(ip, ping_timeout)
 }
 
 func (s *Server) AddClient(client *Client) {
@@ -241,12 +241,12 @@ type RealGamePingerFactory struct {
 	server *Server
 }
 
-func (gpf RealGamePingerFactory) New(client *Client, timeout time.Duration) *GamePinger {
+func (gpf RealGamePingerFactory) New(ip string, timeout time.Duration) *GamePinger {
 	pinger := &GamePinger{make(chan bool)}
 
 	data := make([]byte, len(NETCMD_METASERVER_PING))
 	go func() {
-		conn, err := net.DialTimeout("tcp", net.JoinHostPort(client.remoteIp(), "7396"), timeout)
+		conn, err := net.DialTimeout("tcp", net.JoinHostPort(ip, "7396"), timeout)
 		if err != nil {
 			pinger.C <- false
 			return


### PR DESCRIPTION
Added IPv6 support to the metaserver. Clients can now connect with IPv4 and IPv6. Other clients are told about and are able to connect to games hosted with both address versions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/widelands/widelands_metaserver/2)
<!-- Reviewable:end -->
