### PR TITLE
Fixed bug that too many IPs might be returned when connecting to games.

### DIFF
--- a/wlms/client.go
+++ b/wlms/client.go
@@ -555,13 +555,13 @@ func (client *Client) Handle_GAME_CONNECT(server *Server, pkg *packet.Packet) Cm
 	} else {
 		// Newer client which supports two IPs
 		// Only send him the IPs he can deal with
-		if client.hasV4 && client.hasV6 && host.otherIp() != "" {
+		if client.hasV4 && client.hasV6 && game.State() == CONNECTABLE_BOTH {
 			// Both client and server have both IPs
 			client.SendPacket("GAME_CONNECT", ipv6, true, ipv4)
-		} else if client.hasV4 && len(ipv4) != 0 {
+		} else if client.hasV4 && game.State() == CONNECTABLE_V4 {
 			// Client and server have an IPv4 address
 			client.SendPacket("GAME_CONNECT", ipv4, false)
-		} else if client.hasV6 && len(ipv6) != 0 {
+		} else if client.hasV6 && game.State() == CONNECTABLE_V6 {
 			// Client and server have an IPv6 address
 			client.SendPacket("GAME_CONNECT", ipv6, false)
 		}


### PR DESCRIPTION
The code checked with which protocols the host was connected to
the metaserver instead of using the reachability of the game.

This is a problem when e.g. behind a NAT/firewall and hosting a game. When the host is connected with IPv4 and IPv6 both IPs are returned to connecting clients. When only IPv4 is relayed by the NAT, the client hangs until the first try with IPv6 times out and IPv4 is tried.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/widelands/widelands_metaserver/5)
<!-- Reviewable:end -->
