### PR TITLE
Fixed bug that reconnects would always fail with WRONG_INFORMATION.

### DIFF
--- a/wlms/client.go
+++ b/wlms/client.go
@@ -432,7 +432,7 @@ func (client *Client) Handle_RELOGIN(server *Server, pkg *packet.Packet) CmdErro
 	}
 
 	informationMatches :=
-		protocolVersion == client.protocolVersion &&
+		protocolVersion == oldClient.protocolVersion &&
 			buildId == oldClient.buildId
 
 	if isRegisteredOnServer {


### PR DESCRIPTION
Fixed bug that automatic reconnects will always fail with the message WRONG_INFORMATION.
To trigger this bug, connect to the metaserver, then freeze the game for 45 seconds (e.g. in debugger). When continuing the metaserver has disconnected the client due to an unanswered ping message. The automatic reconnect of the game fails with logout(WRONG_INFORMATION) on the console.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/widelands/widelands_metaserver/6)
<!-- Reviewable:end -->
