### PR TITLE
Replacing references to launchpad

### DIFF
--- a/wlms/client.go
+++ b/wlms/client.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"fmt"
-	"launchpad.net/widelands-metaserver/wlms/packet"
+	"github.com/widelands_metaserver/wlms/packet"
 	"log"
 	"net"
 	"reflect"

--- a/wlms/fake_conn.go
+++ b/wlms/fake_conn.go
@@ -3,7 +3,7 @@ package main
 import (
 	"io"
 	. "launchpad.net/gocheck"
-	"launchpad.net/widelands-metaserver/wlms/packet"
+	"github.com/widelands_metaserver/wlms/packet"
 	"net"
 )
 

--- a/wlms/fake_conn.go
+++ b/wlms/fake_conn.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"io"
-	. "launchpad.net/gocheck"
+	. "gopkg.in/check.v1"
 	"github.com/widelands_metaserver/wlms/packet"
 	"net"
 )

--- a/wlms/server_test.go
+++ b/wlms/server_test.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	. "launchpad.net/gocheck"
+	. "gopkg.in/check.v1"
 	"github.com/widelands_metaserver/wlms/packet"
 	"log"
 	"testing"

--- a/wlms/server_test.go
+++ b/wlms/server_test.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	. "launchpad.net/gocheck"
-	"launchpad.net/widelands-metaserver/wlms/packet"
+	"github.com/widelands_metaserver/wlms/packet"
 	"log"
 	"testing"
 	"time"


### PR DESCRIPTION
Since we are using github to host this project, this replaces references to files in our launchpad repository with their github paths.

Right now, building this project also requires to check out its launchpad version. This probably also means that the packet.go file in this repository is ignored and always its launchpad version is used (haven't tested it).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/widelands/widelands_metaserver/7)
<!-- Reviewable:end -->
