### PR TITLE
Fixed bug with Disconnect() call on wrong object.

### DIFF
--- a/wlms/client.go
+++ b/wlms/client.go
@@ -198,7 +198,7 @@ func DealWithNewConnection(conn ReadWriteCloserWithIp, server *Server) {
 
 			cmdName, err := pkg.ReadString()
 			if err != nil {
-				client.pendingRelogin.Disconnect(*server)
+				client.Disconnect(*server)
 				return
 			}
 


### PR DESCRIPTION
I am not completely sure whether this really is wrong, so please take a look at the surrounding lines. But I think this is a copy&paste mistake and we just got lucky until now.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/widelands/widelands_metaserver/9)
<!-- Reviewable:end -->
