### PR TITLE
Restricting maximum number of clients for one relay game.

### DIFF
--- a/wlnr/game.go
+++ b/wlnr/game.go
@@ -96,6 +96,12 @@ func (game *Game) addClient(client *Client, version uint8, password string) {
 			client.Disconnect("WRONG_VERSION")
 			return
 		}
+		if game.nextClientId >= 250 {
+			// Avoid overflow of uint8 id
+			log.Printf("Too many clients in game %v, disconnecting new client", game.Name())
+			client.Disconnect("NORMAL")
+			return
+		}
 		client.id = game.nextClientId
 		game.nextClientId = game.nextClientId + 1
 		game.clients.PushBack(client)


### PR DESCRIPTION
Simple fix for possible overflow of the uint8 client id. The id is local to each game on the relay. It is increased every time a player (re-)connects to a game, so with 250 possible connects the new code will probably never be reached.

From the in-game side there is an open game in the lobby but joining it drops the player in the main menu with an error message. Works, but not that pretty.
A nicer fix would be to send a RPC message to the metaserver when a game is full so it can be listed as unconnectable. No problem implementing this, but I am not sure whether its worth the (slightly) increased complexity.