### PR TITLE
Displaying the IRC users in the Widelands-Lobby

### DIFF
--- a/wlms/client.go
+++ b/wlms/client.go
@@ -163,7 +163,9 @@ func (client *Client) Disconnect(server Server) {
 }
 
 func (client *Client) SendPacket(data ...interface{}) {
-	client.conn.Write(packet.New(data...))
+	if client.conn != nil {
+		client.conn.Write(packet.New(data...))
+	}
 }
 
 func DealWithNewConnection(conn ReadWriteCloserWithIp, server *Server) {
@@ -289,6 +291,17 @@ func newClient(r ReadWriteCloserWithIp) *Client {
 		startToPingTimer:  time.NewTimer(time.Hour * 1),
 		timeoutTimer:      time.NewTimer(time.Hour * 1),
 		replaceCandidates: nil,
+	}
+	return client
+}
+
+func NewIRCClient(nick string) *Client {
+	client := &Client{
+		state:       CONNECTED,
+		permissions: UNREGISTERED,
+		userName:    nick,
+		buildId:     "IRC",
+		nonce:       "irc",
 	}
 	return client
 }

--- a/wlms/ircbridge.go
+++ b/wlms/ircbridge.go
@@ -6,10 +6,15 @@ import (
 	"strings"
 )
 
+// Structure with channels for communication between IRCBridger and the metaserver
 type IRCBridgerChannels struct {
+	// Messages sent by IRC users that should be displayed in the lobby
 	messagesFromIRC  chan Message
+	// Messages from players in the lobby that should be relayed to IRC
 	messagesToIRC chan Message
+	// Clients joining the IRC channel that should be added to the client list in the lobby
 	clientsJoiningIRC chan string
+	// Clients leaving the IRC channel
 	clientsLeavingIRC chan string
 }
 

--- a/wlms/main.go
+++ b/wlms/main.go
@@ -47,9 +47,11 @@ func main() {
 
 	messagesToIrc := make(chan Message, 50)
 	messagesToLobby := make(chan Message, 50)
+	ircClientsJoining := make(chan string, 50)
+	ircClientsQuitting := make(chan string, 50)
 	if ircbridge != nil {
-		ircbridge.Connect(messagesToIrc, messagesToLobby)
+		ircbridge.Connect(messagesToIrc, messagesToLobby, ircClientsJoining, ircClientsQuitting)
 	}
-	RunServer(db, messagesToLobby, messagesToIrc)
+	RunServer(db, messagesToLobby, messagesToIrc, ircClientsJoining, ircClientsQuitting)
 
 }

--- a/wlms/main.go
+++ b/wlms/main.go
@@ -45,13 +45,10 @@ func main() {
 	}
 	defer db.Close()
 
-	messagesToIrc := make(chan Message, 50)
-	messagesToLobby := make(chan Message, 50)
-	ircClientsJoining := make(chan string, 50)
-	ircClientsQuitting := make(chan string, 50)
+	channels := NewIRCBridgerChannels()
 	if ircbridge != nil {
-		ircbridge.Connect(messagesToIrc, messagesToLobby, ircClientsJoining, ircClientsQuitting)
+		ircbridge.Connect(channels)
 	}
-	RunServer(db, messagesToLobby, messagesToIrc, ircClientsJoining, ircClientsQuitting)
+	RunServer(db, channels)
 
 }

--- a/wlms/packet/packet.go
+++ b/wlms/packet/packet.go
@@ -27,7 +27,7 @@ func New(rawData ...interface{}) []byte {
 				nbytes += len("false") + 1
 			}
 		default:
-			log.Fatal("Unknown type in New().")
+			log.Fatalf("Unknown type in packet.New(), got %T", v)
 		}
 	}
 

--- a/wlms/server.go
+++ b/wlms/server.go
@@ -36,7 +36,7 @@ type Server struct {
 
 	clientForgetTimeout time.Duration
 	gamePingerFactory   GamePingerFactory
-	messagesOut         chan Message
+	irc                 *IRCBridgerChannels
 	relay               *rpc.Client
 	// The IP addresses of the wlnr instance
 	relay_address AddressPair
@@ -129,7 +129,7 @@ func (s *Server) RemoveClient(client *Client) {
 		if e.Value.(*Client) == client {
 			log.Printf("Removing client %s", client.Name())
 			s.clients.Remove(e)
-			s.messagesOut <- Message{
+			s.irc.messagesToIRC <- Message{
 				message: client.Name() + " has left the lobby",
 				nick:    client.Name(),
 			}
@@ -251,7 +251,7 @@ func (s *Server) BroadcastToConnectedClients(data ...interface{}) {
 
 func (s Server) BroadcastToIrc(message string) {
 	select {
-	case s.messagesOut <- Message{
+	case s.irc.messagesToIRC <- Message{
 		message: message,
 	}:
 	default:
@@ -283,7 +283,7 @@ func (rpc *ServerRPC) GameClosed(in *rpc_data.NewGameData, response *bool) (err 
 
 // End mini RPC class
 
-func RunServer(db UserDb, messagesIn chan Message, messagesOut chan Message, ircClientsJoining chan string, ircClientsQuitting chan string) {
+func RunServer(db UserDb, irc *IRCBridgerChannels) {
 	ln, err := net.Listen("tcp", ":7395")
 	if err != nil {
 		log.Fatal(err)
@@ -318,7 +318,7 @@ func RunServer(db UserDb, messagesIn chan Message, messagesOut chan Message, irc
 		}
 	}()
 
-	server := CreateServerUsing(C, db, messagesIn, messagesOut, ircClientsJoining, ircClientsQuitting, relay)
+	server := CreateServerUsing(C, db, irc, relay)
 
 	// Run our rpc server
 	rpc.Register(NewServerRPC(server))
@@ -409,7 +409,7 @@ func (server *Server) GetRelayAddresses() AddressPair {
 	return server.relay_address
 }
 
-func CreateServerUsing(acceptedConnections chan ReadWriteCloserWithIp, db UserDb, messagesIn chan Message, messagesOut chan Message, ircClientsJoining chan string, ircClientsQuitting chan string, relay *rpc.Client) *Server {
+func CreateServerUsing(acceptedConnections chan ReadWriteCloserWithIp, db UserDb, irc *IRCBridgerChannels, relay *rpc.Client) *Server {
 	server := &Server{
 		acceptedConnections:    acceptedConnections,
 		shutdownServer:         make(chan bool),
@@ -422,7 +422,7 @@ func CreateServerUsing(acceptedConnections chan ReadWriteCloserWithIp, db UserDb
 		pingCycleTime:          time.Second * 15,
 		clientSendingTimeout:   time.Minute * 2,
 		clientForgetTimeout:    time.Minute * 5,
-		messagesOut:            messagesOut,
+		irc:                    irc,
 		relay:                  relay,
 		relay_address:          AddressPair{"", ""},
 	}
@@ -452,14 +452,14 @@ func CreateServerUsing(acceptedConnections chan ReadWriteCloserWithIp, db UserDb
 	go func() {
 		for {
 			select {
-			case m := <-messagesIn:
+			case m := <-irc.messagesFromIRC:
 				server.BroadcastToConnectedClients("CHAT", m.nick, m.message, "public")
-			case nick := <-ircClientsJoining:
+			case nick := <-irc.clientsJoiningIRC:
 				client := NewIRCClient(nick)
 				// Not using AddClient() since we don't want a broadcast to IRC here
 				server.clients.PushBack(client)
 				server.BroadcastToConnectedClients("CLIENTS_UPDATE")
-			case nick := <-ircClientsQuitting:
+			case nick := <-irc.clientsLeavingIRC:
 				client := server.HasClient(nick)
 				if client != nil {
 					server.RemoveClient(client)


### PR DESCRIPTION
IRC nicknames are displayed in the Widelands lobby as users with a build version of "IRC".

Handles the metaserver-side of issue #3.

This branch probably shouldn't be merged/deployed immediately. With a low window size / resolution the IRC users fill the player list, forcing the user to use the scrollbar to see the "real" players in the lobby. On the side of the Widelands client a button to hide them might be an idea, and/or listing the IRC users at the bottom of the list by default.