### PR TITLE
Doubled users

### DIFF
--- a/wlms/server.go
+++ b/wlms/server.go
@@ -114,14 +114,22 @@ func (s *Server) AddClient(client *Client) {
 func (s *Server) RemoveClient(client *Client) {
 	// Sanity check: make sure this user is not in our list of clients more than
 	// once.
-	cnt := 0
+	cntGame := 0
+	cntIRC := 0
 	for e := s.clients.Front(); e != nil; e = e.Next() {
 		if e.Value.(*Client).Name() == client.Name() {
-			cnt++
+			if e.Value.(*Client).buildId == "IRC" {
+				cntIRC++
+			} else {
+				cntGame++
+			}
 		}
 	}
-	if cnt > 1 {
-		log.Printf("Warning: %s is in the client list %d times", client.Name(), cnt)
+	if cntIRC > 1 {
+		log.Printf("Warning: IRC client %s is in the client list %d times", client.Name(), cntIRC)
+	}
+	if cntGame > 1 {
+		log.Printf("Warning: Game client %s is in the client list %d times", client.Name(), cntGame)
 	}
 
 	// Now remove the client for good if it is around.


### PR DESCRIPTION
Better handling of which join/disconnect messages are sent to IRC.
Fixing problem with the "detect doubled users" warning code when an ingame user has the same name as an IRC user.

There is still a certain inconsistency: An ingame user can't select the same name as an already logged in IRC user (this is good). The other way round is possible since we have no influence on the usernames in IRC. Could be "fixed" by modifying the usernames of IRC users inside the lobby but I am not convinced of that idea, since IRC users would have different names depending whether they are seen in the lobby or with an IRC client.

No parallel update of the client is required.