### PR TITLE
Fixes for game listing

### DIFF
--- a/wlms/game.go
+++ b/wlms/game.go
@@ -42,6 +42,7 @@ type Game struct {
 	host       string
 	players    map[string]bool
 	name       string
+	buildId    string
 	maxPlayers int
 	state      GameState
 	usesRelay  bool // True if all network traffic passes through our relay server.
@@ -158,10 +159,11 @@ func (game *Game) pingCycle(server *Server) {
 }
 
 // TODO(Notabilis): Remove all this useless maxPlayers stuff or find a use for it. Currently its always 1024.
-func NewGame(host string, server *Server, gameName string, maxPlayers int, shouldUseRelay bool) *Game {
+func NewGame(host string, buildId string, server *Server, gameName string, maxPlayers int, shouldUseRelay bool) *Game {
 	game := &Game{
 		players:    make(map[string]bool),
 		host:       host,
+		buildId:    buildId,
 		name:       gameName,
 		maxPlayers: maxPlayers,
 		state:      INITIAL_SETUP,
@@ -177,6 +179,10 @@ func NewGame(host string, server *Server, gameName string, maxPlayers int, shoul
 
 func (g Game) Name() string {
 	return g.name
+}
+
+func (g Game) BuildId() string {
+	return g.buildId
 }
 
 func (g Game) State() GameState {

--- a/wlms/game.go
+++ b/wlms/game.go
@@ -112,7 +112,9 @@ func (game *Game) doPing(server *Server, host string, pingTimeout time.Duration)
 
 func (game *Game) pingCycle(server *Server) {
 	// Remember to remove the game when we no longer receive pings.
-	defer server.RemoveGame(game)
+	if !game.usesRelay {
+		defer server.RemoveGame(game)
+	}
 
 	first_ping := true
 	ping_primary_ip := true
@@ -210,8 +212,12 @@ func (g *Game) AddPlayer(userName string) {
 
 func (g *Game) RemovePlayer(userName string, server *Server) {
 	if userName == g.host {
-		log.Printf("Host %v leaves game '%v'. This ends the game", userName, g.name)
-		server.RemoveGame(g)
+		if !g.usesRelay {
+			log.Printf("Host %v leaves self-hosted game '%v'. This ends the game", userName, g.name)
+			server.RemoveGame(g)
+		} else {
+			log.Printf("Host %v leaves game '%v' on relay.", userName, g.name)
+		}
 		return
 	}
 

--- a/wlms/game.go
+++ b/wlms/game.go
@@ -216,7 +216,7 @@ func (g *Game) RemovePlayer(userName string, server *Server) {
 			log.Printf("Host %v leaves self-hosted game '%v'. This ends the game", userName, g.name)
 			server.RemoveGame(g)
 		} else {
-			log.Printf("Host %v leaves game '%v' on relay.", userName, g.name)
+			log.Printf("Host %v leaves game '%v' on relay", userName, g.name)
 		}
 		return
 	}

--- a/wlnr/client.go
+++ b/wlnr/client.go
@@ -117,6 +117,9 @@ func (c *Client) SendCommand(cmd *Command) {
 
 // Sends a disconnect message and closes the connection
 func (c *Client) Disconnect(reason string) {
+	if c.conn == nil {
+		return
+	}
 	log.Printf("Disconnecting client (id=%v) because %v\n", c.id, reason)
 	cmd := NewCommand(kDisconnect)
 	cmd.AppendString(reason)

--- a/wlnr/client.go
+++ b/wlnr/client.go
@@ -8,7 +8,7 @@ import (
 	"time"
 )
 
-const PING_INTERVAL_S = 30
+const PING_INTERVAL_S = 15
 
 // Structure to bundle the TCP connection with its packet buffer
 type Client struct {

--- a/wlnr/client.go
+++ b/wlnr/client.go
@@ -8,7 +8,7 @@ import (
 	"time"
 )
 
-const PING_INTERVAL_S = 15
+const PING_INTERVAL_S = 90
 
 // Structure to bundle the TCP connection with its packet buffer
 type Client struct {

--- a/wlnr/game.go
+++ b/wlnr/game.go
@@ -57,6 +57,7 @@ func NewGame(name, password string, server *Server) *Game {
 		server:                server,
 		currentlyShuttingDown: false,
 	}
+	time.AfterFunc(30 * time.Second, func() { server.CheckGameForHost(name) })
 	return game
 }
 

--- a/wlnr/game.go
+++ b/wlnr/game.go
@@ -57,7 +57,7 @@ func NewGame(name, password string, server *Server) *Game {
 		server:                server,
 		currentlyShuttingDown: false,
 	}
-	time.AfterFunc(30 * time.Second, func() { server.CheckGameForHost(name) })
+	time.AfterFunc(30 * time.Second, func() { server.RemoveGameIfNoHostIsConnected(name) })
 	return game
 }
 

--- a/wlnr/server.go
+++ b/wlnr/server.go
@@ -59,7 +59,7 @@ func (s *Server) GameConnected(name string) {
 }
 
 // Search for a game with the given name. If it exists but no host is connected, remove it
-func (s *Server) CheckGameForHost(name string) {
+func (s *Server) RemoveGameIfNoHostIsConnected(name string) {
 	for e := s.games.Front(); e != nil; e = e.Next() {
 		g := e.Value.(*Game)
 		if g.Name() == name && g.host == nil {

--- a/wlnr/server.go
+++ b/wlnr/server.go
@@ -58,6 +58,23 @@ func (s *Server) GameConnected(name string) {
 	s.wlms.Call("ServerRPC.GameConnected", data, &ignored)
 }
 
+// Search for a game with the given name. If it exists but no host is connected, remove it
+func (s *Server) CheckGameForHost(name string) {
+	for e := s.games.Front(); e != nil; e = e.Next() {
+		g := e.Value.(*Game)
+		if g.Name() == name && g.host == nil {
+			log.Printf("Removing game %v since no host connected to it", name)
+			var ignored bool
+			data := rpc_data.NewGameData{
+				Name: name,
+			}
+			s.wlms.Call("ServerRPC.GameClosed", data, &ignored)
+			s.games.Remove(e)
+			return
+		}
+	}
+}
+
 func (s *Server) RemoveGame(game *Game) {
 	for e := s.games.Front(); e != nil; e = e.Next() {
 		if e.Value.(*Game) == game {


### PR DESCRIPTION
Fixes a bunch of problems regarding listed games.
1) Storing buildId of the game host in the game struct on the metaserver instead of asking the host. The host could become disconnected from the metaserver but still being connected to the relay and running the game. In that case, trying to retrieve the buildId from the no-longer existing host entry crashes the metaserver.
2) Increased time interval of the relay ping code to 90 seconds. When loading a map or game, the network code in the client is not run and the connection to the relay could be lost due to a timeout. This is no problem for the metaserver but ends the game in case of a lost connection to the relay. A disadvantage of this increase is that a running game is paused for a longer time until the game host considers a client connection lost. Another solution would be better but I am not sure which one (probably moving the receive() and ping-answer code in the client to a thread).
3) When the game host looses connection to the metaserver, only remove its game from the list when it is the network host (i.e. build19 or older). The relay will tell us when the host looses the connection to its relayed game so we can keep it in the list until then.
4) When a host does not connect to the game it created on the relay, close the game after 30 seconds. This case shouldn't happen normally but might due to bad timing of a lost connection or a deliberate attack.
5) Only send a relay client the first disconnect message when ordered to. Multiple messages can happen when a client times out. For some reason, trying to send(?) on an already closed(?) socket aborts(?) the method execution, making the method never return. When happening to a game host this results in the game still existing on the relay, making further games with the same name impossible.

No parallel update of the client is required.