### PR TITLE
Improved password security

### DIFF
--- a/wlms/client.go
+++ b/wlms/client.go
@@ -37,6 +37,7 @@ type State int
 
 const (
 	HANDSHAKE State = iota
+	TELL_IP
 	CONNECTED
 	RECENTLY_DISCONNECTED
 )
@@ -119,6 +120,8 @@ func (c *Client) setState(s State, server Server) {
 		need_broadcast = c.state == CONNECTED
 	case CONNECTED:
 		need_broadcast = c.state == HANDSHAKE || c.state == RECENTLY_DISCONNECTED
+	case TELL_IP:
+		break
 	default:
 		log.Fatal("Unkown state in setState")
 	}
@@ -436,11 +439,65 @@ func (c *Client) Handle_LOGIN(server *Server, pkg *packet.Packet) CmdError {
 		if !server.UserDb().ContainsName(c.userName) {
 			return CriticalCmdPacketError{"WRONG_PASSWORD"}
 		}
-		if !server.UserDb().PasswordCorrect(c.userName, c.nonce) {
-			return CriticalCmdPacketError{"WRONG_PASSWORD"}
+		if c.protocolVersion >= 4 {
+			// Send a challenge for secure passwort transmission
+			c.sendChallenge(server)
+			return nil
 		}
-		c.permissions = server.UserDb().Permissions(c.userName)
+		failed := c.checkCredentialsLegacy(server)
+		if failed != nil {
+			return failed
+		}
 	}
+	return c.findReplaceCandidates(server, false)
+}
+
+func (c *Client) sendChallenge(server *Server) {
+	// The nonce is empty when using challenge-response. Use it to store the response
+	var challenge string
+	var success bool
+	challenge, c.nonce, success = server.UserDb().GenerateChallengeResponsePair(c.userName)
+	if !success {
+		// Should not happen, but who knows
+		c.Disconnect(*server)
+		return
+	}
+	c.SendPacket("PWD_CHALLENGE", challenge)
+}
+
+func (c *Client) Handle_PWD_CHALLENGE(server *Server, pkg *packet.Packet) CmdError {
+	var response string
+	if err := pkg.Unpack(&response); err != nil {
+		return CriticalCmdPacketError{err.Error()}
+	}
+	if c.nonce != response {
+		return CriticalCmdPacketError{"WRONG_PASSWORD"}
+	}
+	// Password is fine
+	switch c.state {
+	case HANDSHAKE:
+		c.permissions = server.UserDb().Permissions(c.userName)
+		c.nonce = "registered"
+		return c.findReplaceCandidates(server, true)
+	case TELL_IP:
+		c.finishTellIp(server)
+	default:
+		c.SendPacket("ERROR", "PWD_CHALLENGE", "Invalid connection state")
+		c.Disconnect(*server)
+	}
+	return nil
+}
+
+func (c *Client) checkCredentialsLegacy(server *Server) CmdError {
+	if !server.UserDb().PasswordCorrect(c.userName, c.nonce) {
+		return CriticalCmdPacketError{"WRONG_PASSWORD"}
+	}
+	c.permissions = server.UserDb().Permissions(c.userName)
+	// Everything fine
+	return nil
+}
+
+func (c *Client) findReplaceCandidates(server *Server, isRegisteredOnServer bool) CmdError {
 	// Check for clients which are using the same nonce
 	c.replaceCandidates = server.FindClientsToReplace(c.nonce, c.userName)
 	if len(c.replaceCandidates) == 0 {
@@ -585,24 +642,40 @@ func (client *Client) Handle_RELOGIN(server *Server, pkg *packet.Packet) CmdErro
 }
 
 func (client *Client) Handle_TELL_IP(server *Server, pkg *packet.Packet) CmdError {
-	var protocolVersion int
-	var name, nonce string
-	if err := pkg.Unpack(&protocolVersion, &name, &nonce); err != nil {
+	if err := pkg.Unpack(&client.protocolVersion, &client.userName, &client.nonce); err != nil {
 		return CmdPacketError{err.Error()}
 	}
 
-	if protocolVersion != 4 {
+	if client.protocolVersion != 4 {
 		return CriticalCmdPacketError{"UNSUPPORTED_PROTOCOL"}
 	}
 
-	old_client := server.HasClient(name)
-	if old_client == nil || old_client.userName != name || old_client.nonce != nonce {
+	old_client := server.HasClient(client.userName)
+	if old_client == nil || old_client.userName != client.userName || old_client.nonce != client.nonce {
 		log.Printf("Someone failed to register an IP for client %v", old_client.Name())
 		return CriticalCmdPacketError{"NOT_LOGGED_IN"}
 	}
 
+	if old_client.permissions == REGISTERED {
+		// Registered user: Force password check
+		client.setState(TELL_IP, *server)
+		client.sendChallenge(server)
+		return nil
+	}
+
+	// Unregistered user. Check nonce and replace the entry
+	client.finishTellIp(server)
+	return nil
+}
+
+func (client *Client) finishTellIp(server *Server) {
 	// We found the existing connection of this client.
 	// Update his IP and close this connection.
+	old_client := server.HasClient(client.userName)
+	if old_client == nil {
+		// Hm. Must have disconnected in the last seconds. Abort.
+		return
+	}
 	old_client.secondaryIp = client.remoteIp()
 	ip := net.ParseIP(old_client.otherIp())
 	if ip.To4() != nil {
@@ -615,8 +688,6 @@ func (client *Client) Handle_TELL_IP(server *Server, pkg *packet.Packet) CmdErro
 	// Tell the client to get a new list of games. The availability of games might have changed now that
 	// he supports more IP versions
 	old_client.SendPacket("GAMES_UPDATE")
-
-	return nil
 }
 
 func (client *Client) Handle_GAME_OPEN(server *Server, pkg *packet.Packet) CmdError {
@@ -636,7 +707,13 @@ func (client *Client) Handle_GAME_OPEN(server *Server, pkg *packet.Packet) CmdEr
 	} else {
 		// Client does support the relay server. Start a game there
 		log.Printf("Starting new game '%v' on relay for host %v", gameName, client.Name())
-		created := server.RelayCreateGame(gameName, client.nonce)
+		challenge, response, success := server.UserDb().GenerateChallengeResponsePair(client.userName)
+		if !success {
+			// Should not happen
+			client.Disconnect(*server)
+			return nil
+		}
+		created := server.RelayCreateGame(gameName, response)
 		if !created {
 			// Not good. Should not happen
 			return CmdPacketError{"RELAY_ERROR"}
@@ -644,11 +721,11 @@ func (client *Client) Handle_GAME_OPEN(server *Server, pkg *packet.Packet) CmdEr
 		game := NewGame(client.userName, client.buildId, server, gameName, maxPlayer, true /* use relay */)
 		ips := server.GetRelayAddresses()
 		if client.hasV4 && client.hasV6 {
-			client.SendPacket("GAME_OPEN", ips.ipv6, true, ips.ipv4)
+			client.SendPacket("GAME_OPEN", challenge, ips.ipv6, true, ips.ipv4)
 		} else if client.hasV4 {
-			client.SendPacket("GAME_OPEN", ips.ipv4, false)
+			client.SendPacket("GAME_OPEN", challenge, ips.ipv4, false)
 		} else if client.hasV6 {
-			client.SendPacket("GAME_OPEN", ips.ipv6, false)
+			client.SendPacket("GAME_OPEN", challenge, ips.ipv6, false)
 		}
 		client.setGame(game, server)
 	}

--- a/wlms/client.go
+++ b/wlms/client.go
@@ -449,7 +449,7 @@ func (c *Client) Handle_LOGIN(server *Server, pkg *packet.Packet) CmdError {
 			return failed
 		}
 	}
-	return c.findReplaceCandidates(server, false)
+	return c.findReplaceCandidates(server, isRegisteredOnServer)
 }
 
 func (c *Client) sendChallenge(server *Server) {
@@ -580,7 +580,9 @@ func (c *Client) findUnconnectedName(server *Server) {
 		oldClient := server.HasClient(c.userName)
 		if oldClient == nil {
 			// Found a free name
-			c.nonce = server.UserDb().GenerateDowngradedUserNonce(baseName, c.userName)
+			if c.protocolVersion >= 4 {
+				c.nonce = server.UserDb().GenerateDowngradedUserNonce(baseName, c.userName)
+			}
 			c.loginDone(server)
 			return
 		}

--- a/wlms/client.go
+++ b/wlms/client.go
@@ -651,7 +651,8 @@ func (client *Client) Handle_TELL_IP(server *Server, pkg *packet.Packet) CmdErro
 	}
 
 	old_client := server.HasClient(client.userName)
-	if old_client == nil || old_client.userName != client.userName || old_client.nonce != client.nonce {
+	if old_client == nil || old_client.userName != client.userName
+			|| (old_client.nonce != client.nonce && old_client.permissions == UNREGISTERED) {
 		log.Printf("Someone failed to register an IP for client %v", old_client.Name())
 		return CriticalCmdPacketError{"NOT_LOGGED_IN"}
 	}

--- a/wlms/client.go
+++ b/wlms/client.go
@@ -419,11 +419,11 @@ func (c *Client) Handle_LOGIN(server *Server, pkg *packet.Packet) CmdError {
 	}
 
 	// Check protocol version
-	if c.protocolVersion != 0 && c.protocolVersion != 3 {
+	if c.protocolVersion != 0 && c.protocolVersion != 4 {
 		return CriticalCmdPacketError{"UNSUPPORTED_PROTOCOL"}
 	}
 
-	if isRegisteredOnServer || c.protocolVersion == 3 {
+	if isRegisteredOnServer || c.protocolVersion >= 3 {
 		nonce, err := pkg.ReadString()
 		if err != nil {
 			return CriticalCmdPacketError{err.Error()}
@@ -537,7 +537,7 @@ func (client *Client) Handle_RELOGIN(server *Server, pkg *packet.Packet) CmdErro
 		return CriticalCmdPacketError{err.Error()}
 	}
 
-	if isRegisteredOnServer || protocolVersion == 3 {
+	if isRegisteredOnServer || protocolVersion >= 3 {
 		n, err := pkg.ReadString()
 		if err != nil {
 			return CriticalCmdPacketError{err.Error()}
@@ -591,7 +591,7 @@ func (client *Client) Handle_TELL_IP(server *Server, pkg *packet.Packet) CmdErro
 		return CmdPacketError{err.Error()}
 	}
 
-	if protocolVersion != 3 {
+	if protocolVersion != 4 {
 		return CriticalCmdPacketError{"UNSUPPORTED_PROTOCOL"}
 	}
 

--- a/wlms/client.go
+++ b/wlms/client.go
@@ -780,7 +780,6 @@ func (client *Client) Handle_GAMES(server *Server, pkg *packet.Packet) CmdError 
 	data[1] = nrGames
 	n := 2
 	server.ForeachGame(func(game *Game) {
-		host := server.HasClient(game.Host())
 		data[n+0] = game.Name()
 		data[n+1] = game.BuildId()
 		// A game is connectable when the client supports the IP version of the game

--- a/wlms/game.go
+++ b/wlms/game.go
@@ -43,7 +43,6 @@ type Game struct {
 	players    map[string]bool
 	name       string
 	buildId    string
-	maxPlayers int
 	state      GameState
 	usesRelay  bool // True if all network traffic passes through our relay server.
 }
@@ -160,14 +159,12 @@ func (game *Game) pingCycle(server *Server) {
 	}
 }
 
-// TODO(Notabilis): Remove all this useless maxPlayers stuff or find a use for it. Currently its always 1024.
-func NewGame(host string, buildId string, server *Server, gameName string, maxPlayers int, shouldUseRelay bool) *Game {
+func NewGame(host string, buildId string, server *Server, gameName string, shouldUseRelay bool) *Game {
 	game := &Game{
 		players:    make(map[string]bool),
 		host:       host,
 		buildId:    buildId,
 		name:       gameName,
-		maxPlayers: maxPlayers,
 		state:      INITIAL_SETUP,
 		usesRelay:  shouldUseRelay,
 	}
@@ -196,10 +193,6 @@ func (g *Game) SetState(server Server, state GameState) {
 		server.BroadcastToConnectedClients("GAMES_UPDATE")
 		log.Printf("Game '%v' is now in state %v", g.Name(), g.state.String())
 	}
-}
-
-func (g Game) MaxPlayers() int {
-	return g.maxPlayers
 }
 
 func (g Game) Host() string {

--- a/wlms/userdb.go
+++ b/wlms/userdb.go
@@ -51,7 +51,11 @@ func (i InMemoryUserDb) PasswordCorrect(name, password string) bool {
 	if !i.ContainsName(name) {
 		return false
 	}
-	return i.users[name].password == password
+	h := sha1.New()
+	io.WriteString(h, password)
+	passwordHash := h.Sum(nil)
+
+	return i.users[name].password == hex.EncodeToString(passwordHash)
 }
 
 func generateChallengeResponsePair(passwordHash string) (string, string, bool) {


### PR DESCRIPTION
Increasing password security by using CHAP for transmitting the password instead of sending it in plaintext. With CHAP, a challenge (random value) is send to the connecting client and the client responds by sending back the cryptographic hash of the challenge concatenated with its secret password. A cryptographic hash function converts an input to a fixed length output while it is practically impossible to convert the output back to the input. Since the server also knows the password, it can also calculate the hash and can check the hashes whether they are equal. An attacker which captures the send hash can not do anything with it: Extracting the password is not possible and sending the hash to the server does not work since the server will send another challenge on next connect.

Also, removed "max. number of players" parameter when opening a game, which has long been obsolete.

This change should only affect new clients, build19 clients should still work with plaintext passwords.