### PR TITLE
Making hostname configurable

### DIFF
--- a/wlms/main.go
+++ b/wlms/main.go
@@ -8,8 +8,8 @@ import (
 )
 
 type Config struct {
-	Database, User, Password, Table, Backend, IRCServer, Nickname, Realname, Channel string
-	UseTLS                                                                           bool
+	Database, User, Password, Table, Backend, IRCServer, Nickname, Realname, Channel, Hostname string
+	UseTLS                                                                                     bool
 }
 
 func (l *Config) ConfigFrom(path string) error {
@@ -27,6 +27,7 @@ func main() {
 
 	var db UserDb
 	var ircbridge IRCBridger
+	hostname := "localhost"
 	if config != "" {
 		log.Println("Loading configuration")
 		var cfg Config
@@ -39,16 +40,19 @@ func main() {
 			db = NewInMemoryDb()
 		}
 		ircbridge = NewIRCBridge(cfg.IRCServer, cfg.Realname, cfg.Nickname, cfg.Channel, cfg.UseTLS)
+
+		if cfg.Hostname != "" {
+			hostname = cfg.Hostname
+		}
 	} else {
 		log.Println("No configuration found, using in-memory database")
 		db = NewInMemoryDb()
 	}
 	defer db.Close()
-
 	channels := NewIRCBridgerChannels()
 	if ircbridge != nil {
 		ircbridge.Connect(channels)
 	}
-	RunServer(db, channels)
+	RunServer(db, channels, hostname)
 
 }

--- a/wlms/server.go
+++ b/wlms/server.go
@@ -296,7 +296,7 @@ func (rpc *ServerRPC) GameClosed(in *rpc_data.NewGameData, response *bool) (err 
 
 // End mini RPC class
 
-func RunServer(db UserDb, irc *IRCBridgerChannels) {
+func RunServer(db UserDb, irc *IRCBridgerChannels, hostname string) {
 	ln, err := net.Listen("tcp", ":7395")
 	if err != nil {
 		log.Fatal(err)
@@ -331,7 +331,7 @@ func RunServer(db UserDb, irc *IRCBridgerChannels) {
 		}
 	}()
 
-	server := CreateServerUsing(C, db, irc, relay)
+	server := CreateServerUsing(C, db, irc, relay, hostname)
 
 	// Run our rpc server
 	rpc.Register(NewServerRPC(server))
@@ -422,7 +422,7 @@ func (server *Server) GetRelayAddresses() AddressPair {
 	return server.relay_address
 }
 
-func CreateServerUsing(acceptedConnections chan ReadWriteCloserWithIp, db UserDb, irc *IRCBridgerChannels, relay *rpc.Client) *Server {
+func CreateServerUsing(acceptedConnections chan ReadWriteCloserWithIp, db UserDb, irc *IRCBridgerChannels, relay *rpc.Client, hostname string) *Server {
 	server := &Server{
 		acceptedConnections:    acceptedConnections,
 		shutdownServer:         make(chan bool),
@@ -440,10 +440,7 @@ func CreateServerUsing(acceptedConnections chan ReadWriteCloserWithIp, db UserDb
 		relay_address:          AddressPair{"", ""},
 	}
 	// Get the IP addresses of our domain
-	// TODO(sirver): This should be configurable for testing. For now you need
-	// to put 'localhost' here if you want to test Widelands locally against the
-	// metaserver + relay.
-	ips, err := net.LookupIP("widelands.org")
+	ips, err := net.LookupIP(hostname)
 	if err != nil {
 		log.Fatal("Failed to resolve own hostname")
 		return nil


### PR DESCRIPTION
Making hostname used for resolution of own IP address configurable to ease testing of the metaserver.