### PR TITLE
Fixing doubled IRC users

### DIFF
--- a/wlms/server.go
+++ b/wlms/server.go
@@ -145,7 +145,7 @@ func (s *Server) RemoveClient(client *Client) {
 				}
 			}
 			s.clients.Remove(e)
-			break;
+			break
 		}
 	}
 }


### PR DESCRIPTION
Currently, IRC users can be listed multiple times in the lobby. This branch fixes the problem by
1) handling an IRC event which tells us about leaving clients (turns out there are two events for this).
2) Making sure an IRC client is not connected before adding it to the lobby (should not be needed any longer but lets be sure).