### PR TITLE
Cleaner transmission of client status

### DIFF
--- a/wlms/client.go
+++ b/wlms/client.go
@@ -848,7 +848,7 @@ func (client *Client) Handle_CLIENTS(server *Server, pkg *packet.Packet) CmdErro
 			}
 		})
 	}
-	data := make([]interface{}, 2+nrClients*5)
+	data := make([]interface{}, 2+nrClients*4)
 
 	data[0] = "CLIENTS"
 	data[1] = nrClients
@@ -865,8 +865,7 @@ func (client *Client) Handle_CLIENTS(server *Server, pkg *packet.Packet) CmdErro
 			data[n+2] = ""
 		}
 		data[n+3] = otherClient.permissions.String()
-		data[n+4] = ""
-		n += 5
+		n += 4
 	})
 	client.SendPacket(data...)
 	return nil

--- a/wlms/client.go
+++ b/wlms/client.go
@@ -837,6 +837,7 @@ func (client *Client) Handle_GAME_DISCONNECT(server *Server, pkg *packet.Packet)
 
 func (client *Client) Handle_CLIENTS(server *Server, pkg *packet.Packet) CmdError {
 	var nrClients int = 0
+	nFields := 4
 	if client.protocolVersion >= 3 {
 		nrClients = server.NrActiveClients()
 	} else {
@@ -847,8 +848,9 @@ func (client *Client) Handle_CLIENTS(server *Server, pkg *packet.Packet) CmdErro
 				nrClients++
 			}
 		})
+		nFields = 5
 	}
-	data := make([]interface{}, 2+nrClients*4)
+	data := make([]interface{}, 2+nrClients*nFields)
 
 	data[0] = "CLIENTS"
 	data[1] = nrClients
@@ -865,7 +867,10 @@ func (client *Client) Handle_CLIENTS(server *Server, pkg *packet.Packet) CmdErro
 			data[n+2] = ""
 		}
 		data[n+3] = otherClient.permissions.String()
-		n += 4
+		if client.protocolVersion < 4 {
+			data[n+4] = ""
+		}
+		n += nFields
 	})
 	client.SendPacket(data...)
 	return nil

--- a/wlms/client.go
+++ b/wlms/client.go
@@ -366,9 +366,14 @@ func (client *Client) Handle_CHAT(server *Server, pkg *packet.Packet) CmdError {
 		server.BroadcastToIrc(client.Name() + ": " + message)
 	} else {
 		recv_client := server.HasClient(receiver)
-		if recv_client != nil {
-			recv_client.SendPacket("CHAT", client.Name(), message, "private")
+		if recv_client == nil {
+			return nil
 		}
+		if recv_client.permissions == IRC {
+			// Bad luck, whispering to IRC is not supported yet
+			client.SendPacket("CHAT", "", "Private messages to IRC users are not supported.", "system")
+		}
+		recv_client.SendPacket("CHAT", client.Name(), message, "private")
 	}
 	return nil
 }

--- a/wlms/client.go
+++ b/wlms/client.go
@@ -16,6 +16,7 @@ const (
 	UNREGISTERED Permissions = iota
 	REGISTERED
 	SUPERUSER
+	IRC
 )
 
 func (p Permissions) String() string {
@@ -26,6 +27,9 @@ func (p Permissions) String() string {
 		return "REGISTERED"
 	case SUPERUSER:
 		return "SUPERUSER"
+	case IRC:
+		return "IRC"
+
 	default:
 		log.Fatalf("Unknown Permissions: %d", p)
 	}
@@ -301,7 +305,7 @@ func newClient(r ReadWriteCloserWithIp) *Client {
 func NewIRCClient(nick string) *Client {
 	client := &Client{
 		state:       CONNECTED,
-		permissions: UNREGISTERED,
+		permissions: IRC,
 		userName:    nick,
 		buildId:     "IRC",
 		nonce:       "irc",
@@ -834,7 +838,7 @@ func (client *Client) Handle_CLIENTS(server *Server, pkg *packet.Packet) CmdErro
 		// Hide IRC users in the lobby of build19 clients. They would appear
 		// at the top of the player list, confusing the user
 		server.ForeachActiveClient(func(otherClient *Client) {
-			if otherClient.buildId != "IRC" {
+			if otherClient.permissions != IRC {
 				nrClients++
 			}
 		})
@@ -845,7 +849,7 @@ func (client *Client) Handle_CLIENTS(server *Server, pkg *packet.Packet) CmdErro
 	data[1] = nrClients
 	n := 2
 	server.ForeachActiveClient(func(otherClient *Client) {
-		if client.protocolVersion < 3 && otherClient.buildId == "IRC" {
+		if client.protocolVersion < 3 && otherClient.permissions == IRC {
 			return
 		}
 		data[n+0] = otherClient.userName


### PR DESCRIPTION
- That a metaserver client is an IRC user is now transmitted as permission instead of as build-id. Avoids the theoretical problem that a Widelands clieng could have a build-id of "IRC".

- When a message to an IRC user is send, reply with a "can't do so" message.

- No longer sending (not existing) "points" of a user when transmitting the client list.

Note: Don't merge/deploy this, I should do that myself since the protocol version has not been changed yet.