### PR TITLE
Bugfixes: Old games, crash, wrong nonce; added testuser

### DIFF
--- a/wlms/client.go
+++ b/wlms/client.go
@@ -532,7 +532,8 @@ func (c *Client) checkCandidates(server *Server) {
 	}
 	var oldClient *Client
 	oldClient, c.replaceCandidates = c.replaceCandidates[0], c.replaceCandidates[1:]
-	if oldClient.userName != c.userName {
+	if oldClient.userName != c.userName && c.permissions != UNREGISTERED {
+		// TODO(Notabilis): This can probably done later when the oldClient really is replaced
 		// Other username: Drop permissions
 		c.nonce = server.UserDb().GenerateDowngradedUserNonce(c.userName, oldClient.userName)
 		c.permissions = UNREGISTERED

--- a/wlms/main.go
+++ b/wlms/main.go
@@ -22,7 +22,9 @@ func (l *Config) ConfigFrom(path string) error {
 
 func main() {
 	var config string
-	flag.StringVar(&config, "config", "", "Database configuration file to read.")
+	var testuser bool
+	flag.StringVar(&config, "config", "", "Configuration file to read.")
+	flag.BoolVar(&testuser, "testuser", false, "Create a \"testuser\" with password \"test\" on startup. Only works with memory user database.")
 	flag.Parse()
 
 	var db UserDb
@@ -47,6 +49,11 @@ func main() {
 	} else {
 		log.Println("No configuration found, using in-memory database")
 		db = NewInMemoryDb()
+	}
+	mdb, ok := db.(*InMemoryUserDb)
+	if ok && testuser {
+		log.Println("Creating testuser in memory user database")
+		mdb.AddUser("testuser", "test", REGISTERED)
 	}
 	defer db.Close()
 	channels := NewIRCBridgerChannels()

--- a/wlnr/client.go
+++ b/wlnr/client.go
@@ -124,8 +124,11 @@ func (c *Client) Disconnect(reason string) {
 	cmd := NewCommand(kDisconnect)
 	cmd.AppendString(reason)
 	c.SendCommand(cmd)
-	c.conn.Close()
+	// Since conn.Close() indirectly calls this method again,
+	// mark the connection as closed before calling it
+	conn := c.conn
 	c.conn = nil
+	conn.Close()
 }
 
 func (c *Client) pingLoop() {

--- a/wlnr/relayinterface/server_rpc.go
+++ b/wlnr/relayinterface/server_rpc.go
@@ -72,7 +72,9 @@ func (server *ServerRPC) callClientMethod(action, gameName string) {
 		// Probably there never was a connection, try to create one now
 		// Isn't done in the constructor since we have a circular dependency between
 		// relay and metaserver
-		server.connect()
+		if (!server.connect()) {
+			return
+		}
 	}
 	var ignored bool
 	data := GameData{


### PR DESCRIPTION
Fixing a bunch of bugs. Related bug report: https://bugs.launchpad.net/widelands/+bug/1777845
In order of appearance in the diff:

client.go:
It could happen that the metaserver changed the nonce of unregistered clients without the client expecting it.. This leads to problems if the client is trying to create a game later on.

main.go:
Not a bug but a feature for local testing: Added a command line option for the metaserver to create a registered testuser.

client.go:
A fix for the reported bug. It could happen that a client got disconnected from the relay (timout due to connection loss) resulting in the game still being reported as online. The change avoids a duplicated call of the disconnect handler which probably lead to the problem. I don't really understand the bug, though: From my understanding, the thread handling the close seems to fail/segfault since it isn't reaching the line where the game is closed. However, this does not lead to any console outputs or crashes of the relay (what I would be expecting in this case). But anyway, the fix seems to work.

server_rpc.go:
The relay only establishes its connection to the metaserver when the first game changes its state. If the metaserver was no longer running when this happened, the relay crashed. The case that the metaserver is closed after the connection was established is already handled correctly.

A version containing this changes is currently deployed for testing.