### PR TITLE
Fixing bugs with "message queue full"

### DIFF
--- a/wlms/client.go
+++ b/wlms/client.go
@@ -166,7 +166,10 @@ func (client *Client) Disconnect(server Server) {
 
 func (client *Client) SendPacket(data ...interface{}) {
 	if client.conn != nil {
-		client.conn.Write(packet.New(data...))
+		_, err := client.conn.Write(packet.New(data...))
+		if err != nil {
+			log.Printf("Warning: Error while sending data to client %v", client.Name())
+		}
 	}
 }
 

--- a/wlms/ircbridge.go
+++ b/wlms/ircbridge.go
@@ -139,6 +139,9 @@ func (bridge *IRCBridge) Connect(channels *IRCBridgerChannels) bool {
 			bridge.connection.Privmsg(bridge.channel, m.message)
 		}
 	}()
+	// Main loop to react to disconnects and automatically reconnect
+	go bridge.connection.Loop()
+	log.Printf("IRC bridge started")
 	return true
 }
 

--- a/wlms/ircbridge.go
+++ b/wlms/ircbridge.go
@@ -83,7 +83,7 @@ func (bridge *IRCBridge) Connect(channels *IRCBridgerChannels) bool {
 			message: event.Message(),
 		}:
 		default:
-			log.Println("IRC Message Queue full.")
+			log.Println("Message queue from IRC full.")
 		}
 	})
 	bridge.connection.AddCallback("JOIN", func(e *irc.Event) {

--- a/wlms/ircbridge.go
+++ b/wlms/ircbridge.go
@@ -1,15 +1,15 @@
 package main
 
 import (
-	"log"
 	"github.com/thoj/go-ircevent"
+	"log"
 	"strings"
 )
 
 // Structure with channels for communication between IRCBridger and the metaserver
 type IRCBridgerChannels struct {
 	// Messages sent by IRC users that should be displayed in the lobby
-	messagesFromIRC  chan Message
+	messagesFromIRC chan Message
 	// Messages from players in the lobby that should be relayed to IRC
 	messagesToIRC chan Message
 	// Clients joining the IRC channel that should be added to the client list in the lobby
@@ -53,8 +53,16 @@ func NewIRCBridge(server, realname, nickname, channel string, tls bool) *IRCBrid
 }
 
 func (bridge *IRCBridge) Connect(channels *IRCBridgerChannels) bool {
+	if bridge.nick == "" || bridge.user == "" {
+		log.Fatalf("Can't start IRC: nick (%s) or user (%s) invalid", bridge.nick, bridge.user)
+		return false
+	}
 	//Create new connection
 	bridge.connection = irc.IRC(bridge.nick, bridge.user)
+	if bridge.connection == nil {
+		log.Fatalf("Can't create IRC connection")
+		return false
+	}
 	//Set options
 	bridge.connection.UseTLS = bridge.useTLS
 	//connection.TLSOptions //set ssl options
@@ -62,7 +70,7 @@ func (bridge *IRCBridge) Connect(channels *IRCBridgerChannels) bool {
 	//Commands
 	err := bridge.connection.Connect(bridge.server) //Connect to server
 	if err != nil {
-		log.Fatalf("Can't connect %s", bridge.server)
+		log.Fatalf("Can't connect to IRC server at %s", bridge.server)
 		return false
 	}
 	bridge.connection.AddCallback("001", func(e *irc.Event) { bridge.connection.Join(bridge.channel) })

--- a/wlms/ircbridge.go
+++ b/wlms/ircbridge.go
@@ -21,7 +21,7 @@ type IRCBridgerChannels struct {
 func NewIRCBridgerChannels() *IRCBridgerChannels {
 	return &IRCBridgerChannels{
 		messagesFromIRC:   make(chan Message, 50),
-		messagesToIRC:     make(chan Message, 50),
+		messagesToIRC:     make(chan Message, 5),
 		clientsJoiningIRC: make(chan string, 50),
 		clientsLeavingIRC: make(chan string, 50),
 	}


### PR DESCRIPTION
Bugfix branch which mainly deals with bugs due to a reconnect of the external IRC server. Should fix bug reports #1 and #34.

When the connection to the IRC server was lost, the metaserver never tried to reconnect. This lead to message buffers running full, resulting in game clients unable to reconnect due to unclean coding: Direct writing to the full message buffer blocked the reconnect-code.