### PR TITLE
Fixing issues with duplicated LOGIN commands

### DIFF
--- a/wlms/client.go
+++ b/wlms/client.go
@@ -577,7 +577,16 @@ func (c *Client) checkCandidates(server *Server) {
 func (c *Client) findUnconnectedName(server *Server) {
 	nameIndex := 0
 	baseName := c.userName
+	loops := 0
 	for {
+		loops++
+		if loops > 1000 {
+			// This code should never be reached but there is an unreproduced bug where this loop
+			// looped forever. See https://github.com/widelands/widelands_metaserver/issues/38
+			log.Printf("ERROR: Tried to find an unused name for client %v but failed 1000 times. This should not happen", baseName)
+			c.Disconnect(*server)
+			return
+		}
 		// Generate new name
 		nameIndex++
 		c.userName = fmt.Sprintf("%s%d", baseName, nameIndex)

--- a/wlms/client.go
+++ b/wlms/client.go
@@ -413,6 +413,10 @@ func (client *Client) Handle_PONG(server *Server, pkg *packet.Packet) CmdError {
 }
 
 func (c *Client) Handle_LOGIN(server *Server, pkg *packet.Packet) CmdError {
+	if c.state == CONNECTED {
+		// Client is already connected? Then LOGIN isn't permitted
+		return CriticalCmdPacketError{"ALREADY_LOGGED_IN"}
+	}
 	var isRegisteredOnServer bool
 	if err := pkg.Unpack(&c.protocolVersion, &c.userName, &c.buildId, &isRegisteredOnServer); err != nil {
 		return CriticalCmdPacketError{err.Error()}

--- a/wlms/client.go
+++ b/wlms/client.go
@@ -168,7 +168,7 @@ func (client *Client) SendPacket(data ...interface{}) {
 	if client.conn != nil {
 		_, err := client.conn.Write(packet.New(data...))
 		if err != nil {
-			log.Printf("Warning: Error while sending data to client %v", client.Name())
+			log.Printf("Warning: Error while sending data to client %v: %v", client.Name(), err)
 		}
 	}
 }

--- a/wlms/client.go
+++ b/wlms/client.go
@@ -352,6 +352,9 @@ func (client *Client) Handle_CHAT(server *Server, pkg *packet.Packet) CmdError {
 	} else {
 		recv_client := server.HasClient(receiver)
 		if recv_client == nil {
+			if client.protocolVersion >= BUILD20 {
+				client.SendPacket("ERROR", "CHAT", "NO_SUCH_USER")
+			}
 			return nil
 		}
 		if recv_client.permissions == IRC {

--- a/wlms/client.go
+++ b/wlms/client.go
@@ -210,6 +210,7 @@ func DealWithNewConnection(conn ReadWriteCloserWithIp, server *Server) {
 					client.pendingLogin.SendPacket("ERROR", "RELOGIN", "CONNECTION_STILL_ALIVE")
 					client.pendingLogin.Disconnect(*server)
 				} else {
+					// replaceCandidates might be an empty list but won't be nil
 					client.pendingLogin.checkCandidates(server)
 				}
 				client.pendingLogin = nil
@@ -233,11 +234,11 @@ func DealWithNewConnection(conn ReadWriteCloserWithIp, server *Server) {
 					log.Printf("Error while handling command %v for client %v: %v", cmdName, client.Name(), pkgErr.What)
 					client.SendPacket("ERROR", cmdName, pkgErr.What)
 				case CriticalCmdPacketError:
-					log.Printf("Error while handling command %v for client %v: %v", cmdName, client.Name(), pkgErr.What)
+					log.Printf("Critical error while handling command %v for client %v: %v", cmdName, client.Name(), pkgErr.What)
 					client.SendPacket("ERROR", cmdName, pkgErr.What)
 					client.Disconnect(*server)
 				case InvalidPacketError:
-					log.Printf("Error while handling command %v from client %v", cmdName, client.Name())
+					log.Printf("Error while handling invalid command %v from client %v", cmdName, client.Name())
 					client.SendPacket("ERROR", "GARBAGE_RECEIVED", "INVALID_CMD")
 					client.Disconnect(*server)
 				default:

--- a/wlms/client.go
+++ b/wlms/client.go
@@ -518,7 +518,7 @@ func (c *Client) findReplaceCandidates(server *Server, isRegisteredOnServer bool
 func (c *Client) loginDone(server *Server) CmdError {
 
 	c.loginTime = time.Now()
-	log.Printf("Client %v logged in (game version %v, protocol version %v)", c.userName, c.buildId, c.protocolVersion)
+	log.Printf("Client %v logged in (%v, version %v, %v)", c.userName, c.buildId, c.protocolVersion, c.permissions)
 
 	c.SendPacket("LOGIN", c.userName, c.permissions.String())
 	if c.protocolVersion <= BUILD19 {

--- a/wlms/game.go
+++ b/wlms/game.go
@@ -76,9 +76,8 @@ func (game *Game) doPing(server *Server, host string, pingTimeout time.Duration)
 }
 
 func (game *Game) pingCycle(server *Server) {
-	// Remember to remove the game when we no longer receive pings.
-	if !game.usesRelay {
-		defer server.RemoveGame(game)
+	if game.usesRelay {
+		log.Fatalf("Error: Started pingCycle for game %v on relay", game.Name())
 	}
 
 	pingTimeout := server.GameInitialPingTimeout()


### PR DESCRIPTION
Fixing issues when an already logged in client sends another (RE)LOGIN command. Shouldn't affect normal operation but catches/avoids some possible errors by checking the current connection state while handling client requests. Should avert recurrences of issue #38.

Added some additional log outputs about the login procedure. Also fixing two smaller issues I noticed while working on the code:
- Tell the client that its private messages can't be send to a not-existing user.
- Fail when told to start a ping cycle to a game on the relay. That just doesn't make any sense and wasn't possible in the past anyway, even though the code suggested it to be possible.