### PR TITLE
Log all unknown IRC events to figure out the IRC ghosts

### DIFF
--- a/wlms/ircbridge.go
+++ b/wlms/ircbridge.go
@@ -151,7 +151,7 @@ func (bridge *IRCBridge) Connect(channels *IRCBridgerChannels) bool {
 		}
 	})
 	bridge.connection.AddCallback("*", func(e *irc.Event) {
-		// Wildcard event: Is triggered for every even
+		// Wildcard event: Is triggered for every event
 		// Log the event and its data. Will probably create a lot of
 		// noise in the logfile but will hopefully tell me which
 		// command creates the IRC "ghosts" (no longer online IRC users,

--- a/wlms/ircbridge.go
+++ b/wlms/ircbridge.go
@@ -150,6 +150,25 @@ func (bridge *IRCBridge) Connect(channels *IRCBridgerChannels) bool {
 			}
 		}
 	})
+	bridge.connection.AddCallback("*", func(e *irc.Event) {
+		// Wildcard event: Is triggered for every even
+		// Log the event and its data. Will probably create a lot of
+		// noise in the logfile but will hopefully tell me which
+		// command creates the IRC "ghosts" (no longer online IRC users,
+		// that are still listed on the metaserver)
+		switch e.Code {
+			case
+				"001",
+				"PRIVMSG",
+				"JOIN",
+				"PART",
+				"QUIT",
+				"353":
+				// Skip the messages we are already handling
+				return
+		}
+		log.Printf("IRC DEBUG: Received event %v", e)
+	})
 	// Main loop to react to disconnects and automatically reconnect
 	go bridge.connection.Loop()
 	log.Printf("IRC bridge started")


### PR DESCRIPTION
Issue #37 provided the clue that renaming oneself on IRC leaves a "ghost" with the old name in the lobby. Since I wasn't able to find out the protocol command for renaming, let's simply log all received IRC commands until it happens again.
If someone is able to provide this information, that would be fine as well.