### PR TITLE
React to renames of IRC users

### DIFF
--- a/wlms/ircbridge.go
+++ b/wlms/ircbridge.go
@@ -165,25 +165,6 @@ func (bridge *IRCBridge) Connect(channels *IRCBridgerChannels) bool {
 			log.Println("IRC Joining Queue full.")
 		}
 	})
-	bridge.connection.AddCallback("*", func(e *irc.Event) {
-		// Wildcard event: Is triggered for every event
-		// Log the event and its data. Will probably create a lot of
-		// noise in the logfile but will hopefully tell me which
-		// command creates the IRC "ghosts" (no longer online IRC users,
-		// that are still listed on the metaserver)
-		switch e.Code {
-			case
-				"001",
-				"PRIVMSG",
-				"JOIN",
-				"PART",
-				"QUIT",
-				"353":
-				// Skip the messages we are already handling
-				return
-		}
-		log.Printf("IRC DEBUG: Received event %v", e)
-	})
 	// Main loop to react to disconnects and automatically reconnect
 	go bridge.connection.Loop()
 	log.Printf("IRC bridge started")

--- a/wlms/ircbridge.go
+++ b/wlms/ircbridge.go
@@ -136,7 +136,7 @@ func (bridge *IRCBridge) Connect(channels *IRCBridgerChannels) bool {
 			log.Println("IRC Quitting Queue full.")
 		}
 	})
-	// NAMREPLY: List of all nicknames in the channel. Send to us when we join
+	// NAMREPLY: List of all nicknames in the channel. Sent to us when we join
 	bridge.connection.AddCallback("353", func(e *irc.Event) {
 		nicks := strings.Fields(e.Message())
 		for _, nick := range nicks {
@@ -151,7 +151,7 @@ func (bridge *IRCBridge) Connect(channels *IRCBridgerChannels) bool {
 		}
 	})
 	bridge.connection.AddCallback("NICK", func(e *irc.Event) {
-		// Someone changed its name
+		// Someone changed their name
 		// Remove old name
 		select {
 		case channels.clientsLeavingIRC <- e.Nick:

--- a/wlms/ircbridge.go
+++ b/wlms/ircbridge.go
@@ -136,7 +136,7 @@ func (bridge *IRCBridge) Connect(channels *IRCBridgerChannels) bool {
 			log.Println("IRC Quitting Queue full.")
 		}
 	})
-	// NAMREPLY: List of all nicknames in the channel. Send when we join
+	// NAMREPLY: List of all nicknames in the channel. Send to us when we join
 	bridge.connection.AddCallback("353", func(e *irc.Event) {
 		nicks := strings.Fields(e.Message())
 		for _, nick := range nicks {
@@ -148,6 +148,21 @@ func (bridge *IRCBridge) Connect(channels *IRCBridgerChannels) bool {
 			default:
 				log.Println("IRC Joining Queue full.")
 			}
+		}
+	})
+	bridge.connection.AddCallback("NICK", func(e *irc.Event) {
+		// Someone changed its name
+		// Remove old name
+		select {
+		case channels.clientsLeavingIRC <- e.Nick:
+		default:
+			log.Println("IRC Quitting Queue full.")
+		}
+		// Add new name
+		select {
+		case channels.clientsJoiningIRC <- e.Message():
+		default:
+			log.Println("IRC Joining Queue full.")
 		}
 	})
 	bridge.connection.AddCallback("*", func(e *irc.Event) {


### PR DESCRIPTION
When an IRC users renames a NICK message is send to the IRC clients (i.e., the metaserver) that has until now been ignored. This lead to the effect that IRC "ghosts" accumulated in the in-game lobby, since the users never logged out with their old user name.