### PR TITLE
Cleaning up self-hosted games that might no longer be running

### DIFF
--- a/wlms/client.go
+++ b/wlms/client.go
@@ -159,6 +159,10 @@ func (client *Client) setGame(game *Game, server *Server) {
 	server.BroadcastToConnectedClients("CLIENTS_UPDATE")
 }
 
+func (client Client) Game() *Game {
+	return client.game
+}
+
 func (client *Client) Disconnect(server Server) {
 	client.conn.Close()
 	client.setState(RECENTLY_DISCONNECTED, server)
@@ -334,6 +338,7 @@ func (client Client) remoteIp() string {
 }
 
 func (newClient *Client) successfulRelogin(server *Server, oldClient *Client) {
+	// legacy function
 	server.RemoveClient(oldClient)
 
 	newClient.SendPacket("RELOGIN")

--- a/wlms/game.go
+++ b/wlms/game.go
@@ -71,6 +71,16 @@ func (game *Game) doPing(server *Server, host string, pingTimeout time.Duration)
 		default:
 			log.Fatalf("Unhandled game.state: %v", game.state)
 		}
+		if !game.usesRelay {
+			host := server.HasClient(game.Host())
+			if host == nil || host.Game() != game {
+				// Can happen if a client has lost connection to the metaserver.
+				// In that case, kick all players and remove the game
+				log.Printf("Removing unconnectable game '%v' of disconnected legacy player %v", game.Name(), game.Host())
+				game.RemovePlayer(game.Host(), server)
+				return result
+			}
+		}
 	}
 	return result
 }


### PR DESCRIPTION
When an older client ( < build-20) hosts a game but looses the connection to the metaserver, the game might stay behind indefinitely. This branch (more or less) fixes the problem by removing the game when it is unreachable and the client no longer feels responsible for it (that is, disconnected or reconnected).

Unfortunately this fix is on the hacky side, since we can't really detect whether the game is still running when it can't be reached by the metaserver. Also, the reconnected client might be listed in the lobby even when it is actually hosting a game. Since the client does not provide any information about that, we can't make any sound estimate whether the game is still running.