### PR TITLE
Remove clients and games after a few days

### DIFF
--- a/wlms/client.go
+++ b/wlms/client.go
@@ -163,6 +163,10 @@ func (client Client) Game() *Game {
 	return client.game
 }
 
+func (c *Client) LoginTime() time.Time {
+	return c.loginTime
+}
+
 func (client *Client) Disconnect(server Server) {
 	client.conn.Close()
 	client.setState(RECENTLY_DISCONNECTED, server)

--- a/wlms/game.go
+++ b/wlms/game.go
@@ -38,7 +38,7 @@ type Game struct {
 	buildId   string
 	state     GameState
 	usesRelay bool // True if all network traffic passes through our relay server.
-	creationTime time.Time
+	timeLastActivity time.Time
 }
 
 type GamePinger struct {
@@ -114,6 +114,9 @@ func (game *Game) pingCycle(server *Server) {
 			}
 			first_ping = false
 		}
+		if connected {
+			game.timeLastActivity = time.Now()
+		}
 
 		pingTimeout = server.GamePingTimeout()
 		time.Sleep(server.GamePingTimeout())
@@ -128,7 +131,7 @@ func NewGame(host string, buildId string, server *Server, gameName string, shoul
 		name:         gameName,
 		state:        INITIAL_SETUP,
 		usesRelay:    shouldUseRelay,
-		creationTime: time.Now(),
+		timeLastActivity: time.Now(),
 	}
 	server.AddGame(game)
 
@@ -162,10 +165,12 @@ func (g Game) Host() string {
 }
 
 func (g *Game) AddPlayer(userName string) {
+	g.timeLastActivity = time.Now()
 	g.players[userName] = true
 }
 
 func (g *Game) RemovePlayer(userName string, server *Server) {
+	g.timeLastActivity = time.Now()
 	if userName == g.host {
 		if !g.usesRelay {
 			log.Printf("Host %v leaves self-hosted game '%v'. This ends the game", userName, g.name)
@@ -190,6 +195,6 @@ func (g Game) UsesRelay() bool {
 	return g.usesRelay
 }
 
-func (g Game) CreationTime() time.Time {
-	return g.creationTime
+func (g Game) TimeLastActivity() time.Time {
+	return g.timeLastActivity
 }

--- a/wlms/game.go
+++ b/wlms/game.go
@@ -38,6 +38,7 @@ type Game struct {
 	buildId   string
 	state     GameState
 	usesRelay bool // True if all network traffic passes through our relay server.
+	creationTime time.Time
 }
 
 type GamePinger struct {
@@ -121,12 +122,13 @@ func (game *Game) pingCycle(server *Server) {
 
 func NewGame(host string, buildId string, server *Server, gameName string, shouldUseRelay bool) *Game {
 	game := &Game{
-		players:   make(map[string]bool),
-		host:      host,
-		buildId:   buildId,
-		name:      gameName,
-		state:     INITIAL_SETUP,
-		usesRelay: shouldUseRelay,
+		players:      make(map[string]bool),
+		host:         host,
+		buildId:      buildId,
+		name:         gameName,
+		state:        INITIAL_SETUP,
+		usesRelay:    shouldUseRelay,
+		creationTime: time.Now(),
 	}
 	server.AddGame(game)
 
@@ -186,4 +188,8 @@ func (g Game) NrPlayers() int {
 
 func (g Game) UsesRelay() bool {
 	return g.usesRelay
+}
+
+func (g Game) CreationTime() time.Time {
+	return g.creationTime
 }

--- a/wlms/server.go
+++ b/wlms/server.go
@@ -455,7 +455,7 @@ func (s *Server) mainLoop() {
 	// when bugs / unexpected states make a client/game survive.
 	// The timer interval should be so big that it is unrealistic for
 	// clients/games to stay online for so long
-	maxOnlineTime := 3 * 24 * time.Hour
+	maxOnlineTime := 7 * 24 * time.Hour
 	timeFormatString := "2006-01-02 15:04:05"
 	cleanupTicker := time.NewTicker(maxOnlineTime)
 	defer cleanupTicker.Stop()

--- a/wlms/server.go
+++ b/wlms/server.go
@@ -483,10 +483,10 @@ func (s *Server) mainLoop() {
 			s.ForeachGame(func(game *Game) {
 				if game.TimeLastActivity().Before(removeBefore) {
 					if !game.UsesRelay() {
-						log.Printf("Warning: Removing game %v which has been created at %v",
+						log.Printf("Warning: Removing game %v, last ping at %v",
 							game.Name(), game.TimeLastActivity().Format(timeFormatString))
 					} else {
-						log.Printf("Warning: Removing relay game %v which has been created at %v",
+						log.Printf("Warning: Removing relay game %v, last change at %v",
 							game.Name(), game.TimeLastActivity().Format(timeFormatString))
 					}
 					s.RemoveGame(game)
@@ -495,7 +495,7 @@ func (s *Server) mainLoop() {
 			for e := s.clients.Front(); e != nil; e = e.Next() {
 				client := e.Value.(*Client)
 				if client.buildId != "IRC" && client.TimeLastMessage().Before(removeBefore) {
-					log.Printf("Warning: Removing client %v which is online since %v",
+					log.Printf("Warning: Removing client %v, last activity at %v",
 						client.Name(), client.TimeLastMessage().Format(timeFormatString))
 					client.SendPacket("DISCONNECT", "CLIENT_TIMEOUT")
 					client.Disconnect(*s)

--- a/wlms/server.go
+++ b/wlms/server.go
@@ -481,22 +481,22 @@ func (s *Server) mainLoop() {
 			// Games have to be checked before clients so the GAMES_UPDATE
 			// message does not get lost when a client is forced to reconnect
 			s.ForeachGame(func(game *Game) {
-				if game.CreationTime().Before(removeBefore) {
+				if game.TimeLastActivity().Before(removeBefore) {
 					if !game.UsesRelay() {
 						log.Printf("Warning: Removing game %v which has been created at %v",
-							game.Name(), game.CreationTime().Format(timeFormatString))
+							game.Name(), game.TimeLastActivity().Format(timeFormatString))
 					} else {
 						log.Printf("Warning: Removing relay game %v which has been created at %v",
-							game.Name(), game.CreationTime().Format(timeFormatString))
+							game.Name(), game.TimeLastActivity().Format(timeFormatString))
 					}
 					s.RemoveGame(game)
 				}
 			})
 			for e := s.clients.Front(); e != nil; e = e.Next() {
 				client := e.Value.(*Client)
-				if client.buildId != "IRC" && client.LoginTime().Before(removeBefore) {
+				if client.buildId != "IRC" && client.TimeLastMessage().Before(removeBefore) {
 					log.Printf("Warning: Removing client %v which is online since %v",
-						client.Name(), client.LoginTime().Format(timeFormatString))
+						client.Name(), client.TimeLastMessage().Format(timeFormatString))
 					client.SendPacket("DISCONNECT", "CLIENT_TIMEOUT")
 					client.Disconnect(*s)
 				}

--- a/wlms/server.go
+++ b/wlms/server.go
@@ -450,6 +450,15 @@ func CreateServerUsing(acceptedConnections chan ReadWriteCloserWithIp, db UserDb
 
 func (s *Server) mainLoop() {
 	defer s.relay.CloseConnection()
+	// Remove (non-IRC) clients and games that are older than this time.
+	// Normally, I expect this never to remove anything, except for
+	// when bugs / unexpected states make a client/game survive.
+	// The timer interval should be so big that it is unrealistic for
+	// clients/games to stay online for so long
+	maxOnlineTime := 3 * 24 * time.Hour
+	timeFormatString := "2006-01-02 15:04:05"
+	cleanupTicker := time.NewTicker(maxOnlineTime)
+	defer cleanupTicker.Stop()
 	for {
 		select {
 		case conn, ok := <-s.acceptedConnections:
@@ -467,6 +476,31 @@ func (s *Server) mainLoop() {
 			close(s.acceptedConnections)
 			s.serverHasShutdown <- true
 			return
+		case <-cleanupTicker.C:
+			removeBefore := time.Now().Add(-maxOnlineTime)
+			// Games have to be checked before clients so the GAMES_UPDATE
+			// message does not get lost when a client is forced to reconnect
+			s.ForeachGame(func(game *Game) {
+				if game.CreationTime().Before(removeBefore) {
+					if !game.UsesRelay() {
+						log.Printf("Warning: Removing game %v which has been created at %v",
+							game.Name(), game.CreationTime().Format(timeFormatString))
+					} else {
+						log.Printf("Warning: Removing relay game %v which has been created at %v",
+							game.Name(), game.CreationTime().Format(timeFormatString))
+					}
+					s.RemoveGame(game)
+				}
+			})
+			for e := s.clients.Front(); e != nil; e = e.Next() {
+				client := e.Value.(*Client)
+				if client.buildId != "IRC" && client.LoginTime().Before(removeBefore) {
+					log.Printf("Warning: Removing client %v which is online since %v",
+						client.Name(), client.LoginTime().Format(timeFormatString))
+					client.SendPacket("DISCONNECT", "CLIENT_TIMEOUT")
+					client.Disconnect(*s)
+				}
+			}
 		}
 	}
 }


### PR DESCRIPTION
Remove clients and games three days after they logged in / were created.
Should never trigger except when bugs are present that keep a client/game listed even though it has been exited. That is, if there really is a client playing for three days without reconnecting it will trigger, but I guess this is quite unlikely.