### PR TITLE
prefix @/+ for admins/registered user in chat

### DIFF
--- a/wlms/client.go
+++ b/wlms/client.go
@@ -358,7 +358,13 @@ func (client *Client) Handle_CHAT(server *Server, pkg *packet.Packet) CmdError {
 	}
 
 	if len(receiver) == 0 {
-		server.BroadcastToConnectedClients("CHAT", client.Name(), message, "public")
+		if client.permissions == SUPERUSER {
+			server.BroadcastToConnectedClients("CHAT", "@ "+client.Name(), message, "public")
+		} else if client.permissions == REGISTERED {
+			server.BroadcastToConnectedClients("CHAT", "+ "+client.Name(), message, "public")
+		} else {
+			server.BroadcastToConnectedClients("CHAT", client.Name(), message, "public")
+		}
 		server.BroadcastToIrc(client.Name() + ": " + message)
 	} else {
 		recv_client := server.HasClient(receiver)


### PR DESCRIPTION
@blotter came up with the idea to prefix @ for admin users and + for registered users in the lobby chat.

This is how it looks like for admins:
<img width="912" alt="Screenshot 2019-04-30 at 12 14 49" src="https://user-images.githubusercontent.com/2091312/56955973-0efdb680-6b43-11e9-9e78-b7fc70557dd2.png">

And this for registered users:
<img width="912" alt="Screenshot 2019-04-30 at 12 16 58" src="https://user-images.githubusercontent.com/2091312/56955985-1ae97880-6b43-11e9-8058-2fe9b1cf7b99.png">
