### PR TITLE
allow private messages to lobby user again

### DIFF
--- a/wlms/client.go
+++ b/wlms/client.go
@@ -362,17 +362,18 @@ func (client *Client) Handle_CHAT(server *Server, pkg *packet.Packet) CmdError {
 		server.BroadcastToIrc(client.Name() + ": " + message)
 	} else {
 		recv_client := server.HasClient(receiver)
+		recv_client_irc := server.HasIRCClient(receiver)
 		if recv_client == nil {
-			if client.protocolVersion >= BUILD20 {
+			if recv_client_irc != nil && recv_client_irc.permissions == IRC {
+				// Bad luck, whispering to IRC is not supported yet
+				client.SendPacket("CHAT", "", "Private messages to IRC users are not supported.", "system")
+			} else if client.protocolVersion >= BUILD20 {
 				client.SendPacket("ERROR", "CHAT", "NO_SUCH_USER")
 			}
 			return nil
+		} else {
+			recv_client.SendPacket("CHAT", client.Name(), message, "private")
 		}
-		if recv_client.permissions == IRC {
-			// Bad luck, whispering to IRC is not supported yet
-			client.SendPacket("CHAT", "", "Private messages to IRC users are not supported.", "system")
-		}
-		recv_client.SendPacket("CHAT", client.Name(), message, "private")
 	}
 	return nil
 }

--- a/wlms/server.go
+++ b/wlms/server.go
@@ -149,7 +149,7 @@ func (s *Server) RemoveClient(client *Client) {
 func (s Server) HasClient(name string) *Client {
 	for e := s.clients.Front(); e != nil; e = e.Next() {
 		client := e.Value.(*Client)
-		if client.Name() == name {
+		if client.Name() == name && client.buildId != "IRC" {
 			return client
 		}
 	}


### PR DESCRIPTION
#47 broke the ability to send private messages to lobby users when the name was also used on IRC. We now check first whether the user exists as lobby user before we inform the sender that private messages cannot be sent to IRC.