### PR TITLE
Checking whether the received packet length fits the minimum length

### DIFF
--- a/wlnr/client.go
+++ b/wlnr/client.go
@@ -99,6 +99,9 @@ func (c *Client) ReadPacket() ([]byte, error) {
 		return length_bytes, error
 	}
 	length := int(length_bytes[0])<<8 | int(length_bytes[1])
+	if length < 2 {
+		return nil, io.ErrUnexpectedEOF
+	}
 	packet := make([]byte, length)
 	packet[0] = length_bytes[0]
 	packet[1] = length_bytes[1]


### PR DESCRIPTION
Hopefully catching a crash due to too short / invalid data packets. Not sure whether this fixes it, though, since I wasn't able to reproduce the error. The error-message is shown below.


panic: runtime error: index out of range

goroutine 413 [running]:
main.(*Client).ReadPacket(0x8c6d4f0, 0x8c6d400, 0x0, 0x0, 0x20b, 0x8ce2d80)
    /widelands_metaserver/wlnr/client.go:103 +0x18d
main.(*Game).handleHostMessages(0x8c50720)
        /widelands_metaserver/wlnr/game.go:273 +0x190
created by main.(*Game).addClient
        /widelands_metaserver/wlnr/game.go:91 +0x68c