### PR TITLE
Allow to receive statistics by RPC

### DIFF
--- a/wlms/server.go
+++ b/wlms/server.go
@@ -443,6 +443,32 @@ func (server *Server) GameClosed(name string) {
 	server.RemoveGame(game)
 }
 
+// The current status has been requested over RPC
+func (s *Server) Status() *relayinterface.ServerStatus {
+	users := 0
+	for e := s.clients.Front(); e != nil; e = e.Next() {
+		c := e.Value.(*Client)
+		if c.State() == CONNECTED && c.Permissions() != IRC {
+			users++
+		}
+	}
+	games := 0
+	openGames := 0
+	for e := s.games.Front(); e != nil; e = e.Next() {
+		g := e.Value.(*Game)
+		games++
+		if g.State() == CONNECTABLE {
+			openGames++
+		}
+	}
+
+	return &relayinterface.ServerStatus{
+		NClients:   users,
+		NGames:     games,
+		NOpenGames: openGames,
+		}
+}
+
 func (server *Server) GetRelayAddresses() AddressPair {
 	return server.relay_address
 }

--- a/wlms/server.go
+++ b/wlms/server.go
@@ -446,10 +446,14 @@ func (server *Server) GameClosed(name string) {
 // The current status has been requested over RPC
 func (s *Server) Status() *relayinterface.ServerStatus {
 	users := 0
+	clientsInGames := 0
 	for e := s.clients.Front(); e != nil; e = e.Next() {
 		c := e.Value.(*Client)
 		if c.State() == CONNECTED && c.Permissions() != IRC {
 			users++
+			if c.Game() != nil {
+				clientsInGames++
+			}
 		}
 	}
 	games := 0
@@ -463,9 +467,10 @@ func (s *Server) Status() *relayinterface.ServerStatus {
 	}
 
 	return &relayinterface.ServerStatus{
-		NClients:   users,
-		NGames:     games,
-		NOpenGames: openGames,
+		NClients:        users,
+		NClientsInGames: clientsInGames,
+		NGames:          games,
+		NOpenGames:      openGames,
 		}
 }
 

--- a/wlnr/relayinterface/client.go
+++ b/wlnr/relayinterface/client.go
@@ -1,9 +1,10 @@
 package relayinterface
 
 type ServerStatus struct {
-	NClients   int // does not count IRC users
-	NGames     int // contains nOpenGames
-	NOpenGames int
+	NClients        int // does not count IRC users
+	NClientsInGames int
+	NGames          int // contains nOpenGames
+	NOpenGames      int
 }
 
 // Client is an interface for communicating with the relay server.

--- a/wlnr/relayinterface/client.go
+++ b/wlnr/relayinterface/client.go
@@ -1,5 +1,11 @@
 package relayinterface
 
+type ServerStatus struct {
+	NClients   int // does not count IRC users
+	NGames     int // contains nOpenGames
+	NOpenGames int
+}
+
 // Client is an interface for communicating with the relay server.
 // Implementing structs should forward the method calls in this
 // interface to the relay server.
@@ -23,4 +29,6 @@ type ClientCallback interface {
 	GameConnected(name string)
 	// The relay notifies that the game with the given name has been closed on the relay.
 	GameClosed(name string)
+	// Request the current status, e.g., number of active users and games.
+	Status() *ServerStatus
 }

--- a/wlnr/relayinterface/client_rpc.go
+++ b/wlnr/relayinterface/client_rpc.go
@@ -143,3 +143,9 @@ func (client *ClientRPCMethods) GameClosed(in *GameData, response *bool) (err er
 	client.client.callback.GameClosed(in.Name)
 	return nil
 }
+
+// GameClosed is called by the relay over rpc when a game has ended.
+func (client *ClientRPCMethods) Status(in *string, response *ServerStatus) (err error) {
+	*response = *client.client.callback.Status()
+	return nil
+}

--- a/wlnr/relayinterface/client_rpc.go
+++ b/wlnr/relayinterface/client_rpc.go
@@ -4,6 +4,7 @@ import (
 	"log"
 	"net"
 	"net/rpc"
+	"net/rpc/jsonrpc"
 	"time"
 )
 
@@ -46,7 +47,16 @@ func NewClientRPC(callback ClientCallback) Client {
 	}
 
 	rpc.Register(clientMethods)
-	go rpc.Accept(rpcLn)
+
+	go func() {
+		for {
+			conn, err := rpcLn.Accept()
+			if err != nil {
+				continue
+			}
+			go jsonrpc.ServeConn(conn)
+		}
+	}()
 
 	return client
 }
@@ -58,7 +68,7 @@ func (client *ClientRPC) connect() bool {
 		log.Printf("Unable to connect to relay server at localhost: %v", err)
 		return false
 	}
-	client.relay = rpc.NewClient(connection)
+	client.relay = jsonrpc.NewClient(connection)
 	log.Println("Connected to relay server")
 	return true
 }


### PR DESCRIPTION
Allows to retrieve the current number of users and games from the metaserver over the RPC interface.