### PR TITLE
Keep the displayed game of a client when it relogins

### DIFF
--- a/wlms/client.go
+++ b/wlms/client.go
@@ -325,6 +325,7 @@ func (client *Client) failedPong(server *Server) {
 			log.Printf("Client %v replaced old client with that name", client.Name())
 			pending := client.pendingLogin
 			pending.userName = client.userName
+			pending.game = client.game
 			server.RemoveClient(client)
 			pending.loginDone(server)
 		}
@@ -766,6 +767,7 @@ func (c *Client) checkCandidates(server *Server) {
 	if oldClient.state == RECENTLY_DISCONNECTED {
 		// Already known as offline
 		c.userName = oldClient.userName
+		c.game = oldClient.game
 		server.RemoveClient(oldClient)
 		c.loginDone(server)
 	} else {


### PR DESCRIPTION
Currently, when a client encounters a connection timeout with the metaserver (e.g., because the client is loading a map and not responding to network pings), the displayed game of the client is cleared when the client reconnects. With this branch the displayed game is copied from the replaced / disconnected client.

The problem with the old approach was that users appeared to be in the lobby but were in fact inside a game and couldn't respond to chat messages. With the new approach clients might be reacting to chat messages / be in the lobby even though they are displayed as in a game. The latter behavior is probably less problematic since the wrongly displayed user can still react to it.