### PR TITLE
Fixing possible crash due to too short packet lengths

### DIFF
--- a/wlms/packet/packet.go
+++ b/wlms/packet/packet.go
@@ -66,6 +66,9 @@ func Read(r io.Reader) (*Packet, error) {
 	if err != nil {
 		return nil, err
 	}
+	if nlen <= 2 {
+		return nil, fmt.Errorf("packet too short")
+	}
 	str, err := readString(r, nlen-2)
 	if err != nil {
 		return nil, err
@@ -139,6 +142,9 @@ func readInt(r io.Reader) (int, error) {
 }
 
 func readString(r io.Reader, nlen int) (string, error) {
+	if nlen <= 0 {
+		return "", fmt.Errorf("length too short")
+	}
 	buf := make([]byte, nlen)
 	if _, err := io.ReadFull(r, buf); err != nil {
 		return "", err


### PR DESCRIPTION
If the metaserver receives data that starts with \0\0 or \0\1, it tries to create a string slice with a negative length which leads to a crash.
This branch fixes this bug by aborting the connection when such data is received, since it shouldn't appear in the normal operation of the server with the official client anyway.

Fixes issue #69.